### PR TITLE
fix(traefik): allow unsafe-inline in swagger-csp script/style-src-elem

### DIFF
--- a/traefik/dynamic/tls.yaml
+++ b/traefik/dynamic/tls.yaml
@@ -26,12 +26,16 @@ http:
     swagger-csp:
       headers:
         customResponseHeaders:
+          # Swagger UI ships inline <script> and <style> blocks for its
+          # bootstrap config — script-src-elem / style-src-elem must allow
+          # 'unsafe-inline' too, otherwise they override the broader
+          # script-src / style-src directives for inline elements.
           Content-Security-Policy: >-
             default-src 'self';
             script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
-            script-src-elem 'self' https://cdn.jsdelivr.net;
+            script-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
             style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
-            style-src-elem 'self' https://cdn.jsdelivr.net;
+            style-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
             img-src 'self' data: https://cdn.jsdelivr.net;
             font-src 'self' https://cdn.jsdelivr.net;
             connect-src 'self' https://cdn.jsdelivr.net;


### PR DESCRIPTION
CSP3 *-elem directives override the broader script-src/style-src for inline <script> and <style> elements. Without 'unsafe-inline' on script-src-elem and style-src-elem, Swagger UI's bootstrap inline blocks were blocked even though script-src had 'unsafe-inline'.

Browser console after the previous swagger-csp deploy:

  Applying inline style violates the following Content Security Policy
  directive 'style-src-elem 'self' https://cdn.jsdelivr.net'. Either the
  'unsafe-inline' keyword [...] is required.