### PR TITLE
fix(scoring): use ioc.value for Domain artifacts, not ioc.address

### DIFF
--- a/Suspicious/Suspicious/score_process/scoring/processing.py
+++ b/Suspicious/Suspicious/score_process/scoring/processing.py
@@ -202,7 +202,7 @@ def process_ioc(ioc, ioc_type, reports, total_scores, total_confidences, is_mali
         if not analyzer_reports:
             return failure
 
-        artifact_value = ioc.value if ioc_type == "hash" else ioc.address
+        artifact_value = ioc.value if ioc_type in ("hash", "domain") else ioc.address
         failure = CortexAnalyzerReports.process_analyzer_reports(
             reports, analyzer_reports, artifact_value, None
         )


### PR DESCRIPTION
process_ioc branched only on ioc_type == "hash" vs everything else, calling ioc.address on the else branch. Domain instances have a .value field, not .address — every domain artifact threw
AttributeError: 'Domain' object has no attribute 'address' during case scoring, surfacing in production as:

  get_report: error processing case 203: 'Domain' object has no attribute 'address'
  File "score_process/scoring/processing.py", line 205, in process_ioc

Extend the .value branch to cover both "hash" and "domain", matching the existing convention in cortex_job.cortex_utils.CortexJob.get_data_value where {"hash", "domain"} share the .value accessor while {"url", "ip", "mail"} use .address.

Pre-existing bug surfaced during Task 10 staging smoke of the new Cortex case-job mapping flow.