### PR TITLE
fix(mail-preview): render the reported message, not the reporter wrapper

### DIFF
--- a/Suspicious/Suspicious/mail_feeder/email_handler/email_handler.py
+++ b/Suspicious/Suspicious/mail_feeder/email_handler/email_handler.py
@@ -26,9 +26,20 @@ class EmailHandlerService:
         self.observables_service = EmailObservablesService()
         self.preview_renderer = Eml2PngRenderer()
 
-    def handle_mail(self, email_data: dict, workdir: str) -> Optional[Mail]:
+    def handle_mail(
+        self,
+        email_data: dict,
+        workdir: str,
+        source_filename: Optional[str] = None,
+    ) -> Optional[Mail]:
         """
         Handles a single email by validating, determining type, and processing it.
+
+        `source_filename` is the basename of the .eml/.msg currently being
+        processed inside `workdir`. When provided it takes precedence over
+        the legacy resolver fallbacks in _generate_mail_preview_png so the
+        preview renders the actual reported message (feeder ingestion:
+        attached .eml) instead of the reporter wrapper (user_submission.eml).
         """
         fetch_mail_logger.debug(email_data)
         data = email_data
@@ -36,12 +47,19 @@ class EmailHandlerService:
 
         if not any([email_list, email_body_list, email_header_list]):
             fetch_mail_logger.debug("Handling new mail")
-            return self._handle_new_mail(data, workdir)
+            return self._handle_new_mail(data, workdir, source_filename)
 
         fetch_mail_logger.debug("Handling existing mail")
-        return self._handle_existing_mail(data, email_list, email_body_list, email_header_list, workdir)
+        return self._handle_existing_mail(
+            data, email_list, email_body_list, email_header_list, workdir, source_filename,
+        )
 
-    def _handle_new_mail(self, data: EmailDataModel, workdir: str) -> Optional[Mail]:
+    def _handle_new_mail(
+        self,
+        data: EmailDataModel,
+        workdir: str,
+        source_filename: Optional[str] = None,
+    ) -> Optional[Mail]:
         with safe_operation("handle_new_mail"):
             fetch_mail_logger.debug("Creating new mail instance")
             try:
@@ -64,7 +82,7 @@ class EmailHandlerService:
 
             mail_instance = self._save_and_update_mail(mail_instance, data)
 
-            self._generate_mail_preview_png(mail_instance, data, workdir)
+            self._generate_mail_preview_png(mail_instance, data, workdir, source_filename)
 
             self._process_rich_observables(mail_instance, data, workdir)
             self._update_times_sent(mail_instance)
@@ -78,6 +96,7 @@ class EmailHandlerService:
         email_body_list: list,
         email_header_list: list,
         workdir: str,
+        source_filename: Optional[str] = None,
     ) -> Optional[Mail]:
         with safe_operation("handle_existing_mail"):
             if email_list:
@@ -91,7 +110,7 @@ class EmailHandlerService:
                 self._save_mail(mail_instance)
                 return mail_instance
 
-        return self._handle_new_mail(data, workdir)
+        return self._handle_new_mail(data, workdir, source_filename)
 
     def _check_existing_data(self, data: EmailDataModel) -> Tuple[List[Mail], list, list]:
         email_list = list(Mail.objects.filter(mail_id=str(data.id)))
@@ -99,23 +118,47 @@ class EmailHandlerService:
         email_header_list = self.header_service.check_email_headers(data.headers) if data.headers else []
         return email_list, email_body_list, email_header_list
 
-    def _generate_mail_preview_png(self, mail_instance: Mail, data: EmailDataModel, workdir: str) -> None:
+    def _generate_mail_preview_png(
+        self,
+        mail_instance: Mail,
+        data: EmailDataModel,
+        workdir: str,
+        source_filename: Optional[str] = None,
+    ) -> None:
         """
         PNG preview generation.
+
+        Resolution order for the source .eml/.msg:
+          1. `source_filename` (the file currently being processed)
+             — this is the *attached* message in feeder ingestion and
+             the renamed `<source_ref>.eml` in web submission. Always
+             the right file to preview when provided.
+          2. `data.id`-based filename (legacy fallback for callers that
+             do not yet thread source_filename through).
+          3. `user_submission.eml` / `.msg` — last-resort fallback so
+             we still produce *some* preview rather than none.
         """
         with safe_operation("generate_mail_preview_png"):
-            try:
-                email_path = self._resolve_file_path(
-                    filename=str(data.id),
-                    workdir=workdir,
-                )
-            except FileNotFoundError:
-                fetch_mail_logger.debug(
-                    "No email file found for preview (mail_id=%s, workdir=%s)",
-                    mail_instance.mail_id,
-                    workdir,
-                )
-                return
+            email_path: Optional[str] = None
+
+            if source_filename:
+                candidate = os.path.join(workdir, source_filename)
+                if os.path.exists(candidate):
+                    email_path = candidate
+
+            if email_path is None:
+                try:
+                    email_path = self._resolve_file_path(
+                        filename=str(data.id),
+                        workdir=workdir,
+                    )
+                except FileNotFoundError:
+                    fetch_mail_logger.debug(
+                        "No email file found for preview (mail_id=%s, workdir=%s)",
+                        mail_instance.mail_id,
+                        workdir,
+                    )
+                    return
 
             png_bytes = self.preview_renderer.render_eml_path_to_png_bytes(
                 Path(email_path)

--- a/Suspicious/Suspicious/mail_feeder/global_submission/gsubmission.py
+++ b/Suspicious/Suspicious/mail_feeder/global_submission/gsubmission.py
@@ -45,7 +45,11 @@ class GlobalSubmissionService:
                 submission.user
             )
 
-            instance = EmailHandlerService().handle_mail(mail_instance, submission.workdir)
+            instance = EmailHandlerService().handle_mail(
+                mail_instance,
+                submission.workdir,
+                source_filename=submission.filename,
+            )
 
             fetch_mail_logger.debug(
                 f"Processed email instance: {instance.mail_id if instance else 'None'}"

--- a/Suspicious/Suspicious/mail_feeder/management/commands/regenerate_mail_previews.py
+++ b/Suspicious/Suspicious/mail_feeder/management/commands/regenerate_mail_previews.py
@@ -183,19 +183,29 @@ class Command(BaseCommand):
 
     @staticmethod
     def _fetch_eml_bytes(storage, bucket_name: str) -> Optional[bytes]:
-        """Stream the first object ending in .eml from the bucket."""
-        objects = storage.client.list_objects(bucket_name, recursive=True)
-        eml_key = None
-        for obj in objects:
-            name = getattr(obj, "object_name", "") or ""
-            if name.lower().endswith(".eml"):
-                eml_key = name
-                # Prefer user_submission.eml when several are present.
-                if name.lower().endswith("user_submission.eml"):
-                    break
+        """Stream the previewable .eml from the bucket.
 
-        if not eml_key:
+        Buckets typically contain both the reporter wrapper
+        (`user_submission.eml`) and the actual reported message (any
+        other .eml). The preview must always render the reported
+        message, never the wrapper. We pick the first non-wrapper .eml
+        and only fall back to user_submission.eml when nothing else
+        exists (e.g. legacy submissions before the split).
+        """
+        objects = list(storage.client.list_objects(bucket_name, recursive=True))
+        eml_keys = [
+            getattr(o, "object_name", "") or "" for o in objects
+            if (getattr(o, "object_name", "") or "").lower().endswith(".eml")
+        ]
+        if not eml_keys:
             return None
+
+        # Prefer any .eml that is NOT the reporter wrapper.
+        non_wrapper = [
+            k for k in eml_keys
+            if not k.lower().endswith("user_submission.eml")
+        ]
+        eml_key = non_wrapper[0] if non_wrapper else eml_keys[0]
 
         response = None
         try:


### PR DESCRIPTION
Preview generation previously called _resolve_file_path(filename=data.id, workdir=workdir), which looks for `<data.id>.eml` and then falls back to `user_submission.eml`. `data.id` is the Message-ID header value (an angle- bracketed string) so the fallback always wins, meaning every preview rendered the wrapper that the reporter sent to the platform — the email ABOUT the suspicious mail — rather than the suspicious mail itself.

Symptom: in the admin and UI, mail previews showed the user's "FW: suspicious mail" wrapper instead of the actual phishing message.

Fix: thread submission.filename (the file currently being processed) through to _generate_mail_preview_png. Both submission paths (web_submission and minio_submission) already iterate list_eml_files(prefix="user_submission") so submission.filename is always the non-wrapper attached/renamed message:

  - Feeder ingestion → attached <message>.eml extracted by email-feeder
  - Web submission   → renamed <source_ref>.eml (the file the user
                       uploaded; user_submission.eml is the raw copy)

In both cases the preview now renders the right file.

Files

mail_feeder/email_handler/email_handler.py
  handle_mail, _handle_existing_mail, _handle_new_mail and
  _generate_mail_preview_png all accept an optional source_filename.
  Resolution order in the renderer:
    1. source_filename when the file exists in workdir
    2. legacy resolver via data.id (keeps callers that haven't updated yet working unchanged)
    3. user_submission.eml as a last-resort fallback

mail_feeder/global_submission/gsubmission.py
  process_single_email now passes submission.filename through to
  handle_mail.

mail_feeder/management/commands/regenerate_mail_previews.py
  Inverted the .eml selection inside the bucket so the regen command
  matches the new runtime behaviour: prefer any non-`user_submission.eml`
  message, fall back to the wrapper only when the bucket has nothing
  else. The previous logic broke `--all` runs by re-rendering every
  preview from the wrong file.

Verification
  - python -c imports + manage.py shell signature check OK
  - python manage.py test mail_feeder.global_submission.tests 10 tests, all passing