### PR TITLE
chore(mail-preview): log selected source file + warn on fallback

### DIFF
--- a/Suspicious/Suspicious/mail_feeder/email_handler/email_handler.py
+++ b/Suspicious/Suspicious/mail_feeder/email_handler/email_handler.py
@@ -140,11 +140,19 @@ class EmailHandlerService:
         """
         with safe_operation("generate_mail_preview_png"):
             email_path: Optional[str] = None
+            picked_via = "none"
 
             if source_filename:
                 candidate = os.path.join(workdir, source_filename)
                 if os.path.exists(candidate):
                     email_path = candidate
+                    picked_via = "source_filename"
+                else:
+                    fetch_mail_logger.warning(
+                        "preview: source_filename %r missing in workdir %s "
+                        "— falling back to legacy resolver",
+                        source_filename, workdir,
+                    )
 
             if email_path is None:
                 try:
@@ -152,6 +160,7 @@ class EmailHandlerService:
                         filename=str(data.id),
                         workdir=workdir,
                     )
+                    picked_via = "legacy_resolver"
                 except FileNotFoundError:
                     fetch_mail_logger.debug(
                         "No email file found for preview (mail_id=%s, workdir=%s)",
@@ -159,6 +168,11 @@ class EmailHandlerService:
                         workdir,
                     )
                     return
+
+            fetch_mail_logger.info(
+                "preview: mail_id=%s rendering %s (via=%s)",
+                mail_instance.mail_id, email_path, picked_via,
+            )
 
             png_bytes = self.preview_renderer.render_eml_path_to_png_bytes(
                 Path(email_path)


### PR DESCRIPTION
The preview generator silently fell back to data.id-based resolution (and ultimately user_submission.eml) when source_filename pointed at a file that did not exist in the workdir. That made it impossible to tell from production logs whether the renderer used the reported message or the reporter wrapper.

Now _generate_mail_preview_png:
- WARNs when source_filename is provided but absent from the workdir (this means something cleaned it up between gsubmission opening it and the renderer running)
- INFOs the picked source path + selection reason (source_filename / legacy_resolver) so any deviation from the expected feeder flow is visible in suspicious_celery logs:

    preview: mail_id=<id> rendering /tmp/.../attached.eml (via=source_filename)

No behavioural change beyond logging.