### PR TITLE
ci: wire test branch into CI gate + staging image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches: [main, test]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, test]
     tags: ["v*"]
   workflow_dispatch:
 
@@ -55,6 +55,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-,enable={{is_default_branch}}
+            type=raw,value=test,enable=${{ github.ref == 'refs/heads/test' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ plus Dependabot live under `.github/`.
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `ci.yml` | PR + push to `main` | Conventional-commit lint, `ruff` lint, migration-drift check, full Django test suite, email-feeder unittest, frontend (eslint + tsc + vitest browser mode + build), and a no-push build of all four images. |
-| `release.yml` | push to `main`, tags `v*` | Builds and pushes all four images to GHCR, generates an SPDX SBOM (syft) and a build-provenance attestation per image. |
+| `ci.yml` | PR to `main`, push to `main` + `test` | Conventional-commit lint, `ruff` lint, migration-drift check, full Django test suite, email-feeder unittest, frontend (eslint + tsc + vitest browser mode + build), and a no-push build of all four images. |
+| `release.yml` | push to `main` + `test`, tags `v*` | Builds and pushes all four images to GHCR with SPDX SBOM (syft) + provenance attestation. `main` → `latest` + `sha-<sha>`; `test` → `test` (staging); `v*` → semver tags. |
 | `codeql.yml` | PR + push to `main`, weekly | CodeQL static analysis for Python and JavaScript/TypeScript. |
 | `security.yml` | PR, weekly | Trivy filesystem scan, gitleaks secret scan, `pip-audit` (×3 requirements), `npm audit`. |
 | `dependabot.yml` | weekly | Dependency updates: pip (×3), npm, docker (×4), github-actions. |


### PR DESCRIPTION
Push to `test` now runs the full ci.yml gate (lint, tests, build) and release.yml builds + pushes all four images tagged `test` to GHCR (staging). main/tag tagging is unchanged: `latest`+`sha` on main, semver on v* — the test tag is gated on `github.ref == 'refs/heads/test'`.

Restores the staging-image flow the removed docker-image-test.yml had, now behind the same test/lint gate as main.