### PR TITLE
fix(ui): exclude public/ from eslint

### DIFF
--- a/suspicious-ui/eslint.config.js
+++ b/suspicious-ui/eslint.config.js
@@ -5,7 +5,7 @@ import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 
 export default [
-  { ignores: ["dist/**", "node_modules/**", ".playwright/**", "src/bones/**"] },
+  { ignores: ["dist/**", "node_modules/**", ".playwright/**", "src/bones/**", "public/**"] },
 
   js.configs.recommended,
 


### PR DESCRIPTION
public/env-config.js is a static browser script (window.__ENV__ placeholder), not application source — js.configs.recommended flagged `window` as no-undef since public/ isn't covered by the TS config block. Add public/** to ignores. `eslint .` is clean again (exit 0; remaining items are non-blocking warnings).