### PR TITLE
test(ui): fix brittle queries in Login/Submit/Investigation suites

### DIFF
--- a/suspicious-ui/src/pages/__tests__/InvestigationPage.test.tsx
+++ b/suspicious-ui/src/pages/__tests__/InvestigationPage.test.tsx
@@ -120,8 +120,9 @@ describe("InvestigationPage", () => {
   it("shows correct result chip for a suspicious case", async () => {
     renderInvestigation();
 
+    // The uppercase chip label "SUSPICIOUS" disambiguates from prose text.
     await waitFor(() => {
-      expect(screen.getByText(/suspicious/i)).toBeInTheDocument();
+      expect(screen.getByText("SUSPICIOUS")).toBeInTheDocument();
     });
   });
 

--- a/suspicious-ui/src/pages/__tests__/LoginPage.test.tsx
+++ b/suspicious-ui/src/pages/__tests__/LoginPage.test.tsx
@@ -30,6 +30,17 @@ function renderLogin(initialPath = "/login") {
   return renderWithProviders(<LoginPage />, { initialPath });
 }
 
+// The username/password form is disclosed behind a button; SSO is shown first.
+async function revealPasswordForm(user: ReturnType<typeof userEvent.setup>) {
+  const disclose = await screen.findByRole("button", {
+    name: /sign in with username and password/i,
+  });
+  await user.click(disclose);
+  await waitFor(() =>
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -42,22 +53,21 @@ describe("LoginPage", () => {
   });
 
   it("renders username and password fields", async () => {
+    const user = userEvent.setup();
     renderLogin();
 
-    await waitFor(() => {
-      expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
-    });
+    await revealPasswordForm(user);
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
   });
 
   it("submit button is disabled when fields are empty", async () => {
+    const user = userEvent.setup();
     renderLogin();
 
-    await waitFor(() => {
-      expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
-    });
+    await revealPasswordForm(user);
 
-    const submitBtn = screen.getByRole("button", { name: /sign in|log in|login/i });
+    const submitBtn = screen.getByRole("button", { name: "Sign in" });
     expect(submitBtn).toBeDisabled();
   });
 
@@ -65,14 +75,12 @@ describe("LoginPage", () => {
     const user = userEvent.setup();
     renderLogin();
 
-    await waitFor(() =>
-      expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
-    );
+    await revealPasswordForm(user);
 
     await user.type(screen.getByLabelText(/username/i), "alice");
     await user.type(screen.getByLabelText(/password/i), "secret");
 
-    const submitBtn = screen.getByRole("button", { name: /sign in|log in|login/i });
+    const submitBtn = screen.getByRole("button", { name: "Sign in" });
     expect(submitBtn).not.toBeDisabled();
   });
 
@@ -86,13 +94,11 @@ describe("LoginPage", () => {
 
     renderLogin();
 
-    await waitFor(() =>
-      expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
-    );
+    await revealPasswordForm(user);
 
     await user.type(screen.getByLabelText(/username/i), "alice");
     await user.type(screen.getByLabelText(/password/i), "secret");
-    await user.click(screen.getByRole("button", { name: /sign in|log in|login/i }));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
 
     await waitFor(() =>
       expect(mockLogin).toHaveBeenCalledWith("alice", "secret")
@@ -107,13 +113,11 @@ describe("LoginPage", () => {
 
     renderLogin();
 
-    await waitFor(() =>
-      expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
-    );
+    await revealPasswordForm(user);
 
     await user.type(screen.getByLabelText(/username/i), "alice");
     await user.type(screen.getByLabelText(/password/i), "wrong");
-    await user.click(screen.getByRole("button", { name: /sign in|log in|login/i }));
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
 
     await waitFor(() =>
       expect(screen.getByText(/invalid credentials/i)).toBeInTheDocument()

--- a/suspicious-ui/src/pages/__tests__/SubmitPage.test.tsx
+++ b/suspicious-ui/src/pages/__tests__/SubmitPage.test.tsx
@@ -54,59 +54,41 @@ describe("SubmitPage", () => {
   it("renders both submission modes", async () => {
     renderSubmit();
 
-    await waitFor(() => {
-      // Both mode cards should be visible
-      expect(screen.getByText(/file|email/i)).toBeInTheDocument();
-      expect(screen.getByText(/url|artifact|indicator/i)).toBeInTheDocument();
-    });
+    // File mode is the default; both mode cards are present.
+    expect(
+      await screen.findByText("Drag and drop or click to browse")
+    ).toBeInTheDocument();
+    expect(screen.getByText("URL, Domain or Indicator")).toBeInTheDocument();
   });
 
   it("shows file dropzone in file mode (default)", async () => {
     renderSubmit();
 
-    await waitFor(() => {
-      // The drop zone or a label like "Drop a file" or "Choose file"
-      expect(
-        screen.getByText(/drop|drag|upload|choose|select/i)
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText("Drag and drop or click to browse")
+    ).toBeInTheDocument();
   });
 
   it("switches to artifact mode and shows text input", async () => {
     const user = userEvent.setup();
     renderSubmit();
 
-    await waitFor(() => {
-      // Look for the artifact/URL mode selector
-      expect(screen.getByText(/url|artifact|indicator/i)).toBeInTheDocument();
-    });
+    await user.click(await screen.findByText("URL, Domain or Indicator"));
 
-    // Click the artifact mode selector
-    const artifactMode = screen.getByText(/url|artifact|indicator/i);
-    await user.click(artifactMode);
-
-    await waitFor(() => {
-      // A text input for the artifact value should appear
-      expect(
-        screen.getByRole("textbox", { name: /url|indicator|value/i })
-      ).toBeInTheDocument();
-    });
+    // The artifact value field (label "URL, domain or indicator") appears.
+    expect(
+      await screen.findByLabelText(/url, domain or indicator/i)
+    ).toBeInTheDocument();
   });
 
   it("submit button is disabled when artifact input is empty", async () => {
     const user = userEvent.setup();
     renderSubmit();
 
-    await waitFor(() =>
-      expect(screen.getByText(/url|artifact|indicator/i)).toBeInTheDocument()
-    );
+    await user.click(await screen.findByText("URL, Domain or Indicator"));
+    await screen.findByLabelText(/url, domain or indicator/i);
 
-    await user.click(screen.getByText(/url|artifact|indicator/i));
-
-    await waitFor(() => {
-      const submitBtn = screen.getByRole("button", { name: /submit|analyze|send/i });
-      expect(submitBtn).toBeDisabled();
-    });
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
   it("submits a URL artifact and calls api.post", async () => {
@@ -124,24 +106,12 @@ describe("SubmitPage", () => {
 
     renderSubmit();
 
-    await waitFor(() =>
-      expect(screen.getByText(/url|artifact|indicator/i)).toBeInTheDocument()
-    );
+    await user.click(await screen.findByText("URL, Domain or Indicator"));
 
-    await user.click(screen.getByText(/url|artifact|indicator/i));
+    const field = await screen.findByLabelText(/url, domain or indicator/i);
+    await user.type(field, "http://evil.example.com/phishing");
 
-    await waitFor(() =>
-      expect(
-        screen.getByRole("textbox", { name: /url|indicator|value/i })
-      ).toBeInTheDocument()
-    );
-
-    await user.type(
-      screen.getByRole("textbox", { name: /url|indicator|value/i }),
-      "http://evil.example.com/phishing"
-    );
-
-    const submitBtn = screen.getByRole("button", { name: /submit|analyze|send/i });
+    const submitBtn = screen.getByRole("button", { name: "Submit" });
     await waitFor(() => expect(submitBtn).not.toBeDisabled());
     await user.click(submitBtn);
 


### PR DESCRIPTION
These three older suites used loose regex text matchers + assumed the LoginPage form was always visible. Once the import break was fixed they ran and failed on (a) "multiple elements" from prose matching and (b) the username field being hidden behind a disclosure button. Rewrote with the exact UI strings (verified against the rendered DOM + component source):

- LoginPage: click "Sign in with username and password" to reveal the form before querying; labels "Username"/"Password"; submit exact "Sign in".
- SubmitPage: target "URL, Domain or Indicator" (mode card), "URL, domain or indicator" (field label), "Drag and drop or click to browse" (dropzone), and the exact "Submit" button.
- InvestigationPage: assert the uppercase chip "SUSPICIOUS" instead of a /suspicious/i regex that also matched the case description prose.

tsc -b passes. (Browser-mode vitest could not be run locally — Chromium OOMs in this Docker host alongside the full stack — but the queries are derived from the actual failure DOM, and the runner launches Chromium fine.)