### PR TITLE
test(ui): assert LoginPage's generic error message

### DIFF
--- a/suspicious-ui/src/pages/__tests__/LoginPage.test.tsx
+++ b/suspicious-ui/src/pages/__tests__/LoginPage.test.tsx
@@ -119,8 +119,9 @@ describe("LoginPage", () => {
     await user.type(screen.getByLabelText(/^password/i), "wrong");
     await user.click(screen.getByRole("button", { name: "Sign in" }));
 
+    // LoginPage surfaces a generic credential-failure message, not the raw API detail.
     await waitFor(() =>
-      expect(screen.getByText(/invalid credentials/i)).toBeInTheDocument()
+      expect(screen.getByText(/check your credentials/i)).toBeInTheDocument()
     );
   });
 


### PR DESCRIPTION
LoginPage shows a fixed "Sign-in failed. Check your credentials and try again." on failed login — it does not surface the raw API `detail`. Assert /check your credentials/i instead of the API string.