### PR TITLE
fix(ui): stop InvestigationPage render loop from unstable reports ref

### DIFF
--- a/suspicious-ui/src/pages/InvestigationPage.tsx
+++ b/suspicious-ui/src/pages/InvestigationPage.tsx
@@ -790,18 +790,23 @@ export default function InvestigationPage() {
     setExpandedGroups({});
   }
 
-  // Collapse analyzer rows when a fresh set of reports arrives.
-  const reportsRef = detailsQuery.data?.analyzer_reports;
-  const [prevReportsRef, setPrevReportsRef] = React.useState(reportsRef);
-  if (reportsRef !== prevReportsRef) { setPrevReportsRef(reportsRef); setExpandedAnalyzerIds({}); }
+  // Collapse analyzer rows when a fresh set of reports arrives. Keyed on the
+  // query's update timestamp (stable across renders, unlike the data array ref).
+  const reportsKey = detailsQuery.dataUpdatedAt;
+  const [prevReportsKey, setPrevReportsKey] = React.useState(reportsKey);
+  if (reportsKey !== prevReportsKey) { setPrevReportsKey(reportsKey); setExpandedAnalyzerIds({}); }
 
-  // Leave edit mode + clear the mutation when switching to another case.
+  // Leave edit mode when switching to another case.
   const [prevSelectedIdNum, setPrevSelectedIdNum] = React.useState(selectedIdNum);
   if (selectedIdNum !== prevSelectedIdNum) {
     setPrevSelectedIdNum(selectedIdNum);
     setEditMode(false);
-    editMutation.reset();
   }
+  // Clear the edit mutation on case change (reset() is a side effect, not setState).
+  React.useEffect(() => {
+    editMutation.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedIdNum]);
 
   // Seed the edit form from fetched details (unless actively editing).
   const editSeedKey = `${openDrawer}|${detailsQuery.dataUpdatedAt}|${editMode}`;

--- a/suspicious-ui/src/pages/SubmissionsPage.tsx
+++ b/suspicious-ui/src/pages/SubmissionsPage.tsx
@@ -887,11 +887,12 @@ export default function SubmissionsPage() {
     setExpandedGroups({});
   }
 
-  // Collapse analyzer rows when a fresh set of reports arrives.
-  const reportsRef = detailsQuery.data?.analyzer_reports;
-  const [prevReportsRef, setPrevReportsRef] = React.useState(reportsRef);
-  if (reportsRef !== prevReportsRef) {
-    setPrevReportsRef(reportsRef);
+  // Collapse analyzer rows when a fresh set of reports arrives. Keyed on the
+  // query's update timestamp (stable across renders, unlike the data array ref).
+  const reportsKey = detailsQuery.dataUpdatedAt;
+  const [prevReportsKey, setPrevReportsKey] = React.useState(reportsKey);
+  if (reportsKey !== prevReportsKey) {
+    setPrevReportsKey(reportsKey);
     setExpandedAnalyzerIds({});
   }
 


### PR DESCRIPTION
The render-time "collapse analyzer rows on new reports" adjustment compared detailsQuery.data?.analyzer_reports by reference. That array ref isn't stable across renders, so the compare was always true -> setExpandedAnalyzerIds({}) (a fresh object) every render -> "Too many re-renders".

Key the reset on detailsQuery.dataUpdatedAt (a number, stable until refetch) instead. Applied to both InvestigationPage and SubmissionsPage (same latent bug; Submissions only escaped it because its tests never open the drawer).

Also move editMutation.reset() out of render into a [selectedIdNum] effect — reset() is a side effect, not setState, so it doesn't trip set-state-in-effect.

tsc -b clean; eslint 0/0. (Browser vitest still not runnable locally — Chromium OOM — but the loop's root cause is removed; the runner will confirm.)