### PR TITLE
test(ui): pre-bundle testing-library deps to fix vitest browser flake

### DIFF
--- a/suspicious-ui/vitest.config.ts
+++ b/suspicious-ui/vitest.config.ts
@@ -5,6 +5,23 @@ import viteConfig from "./vite.config";
 export default mergeConfig(
   viteConfig,
   defineConfig({
+    // Pre-bundle the shared test dependencies up front. Otherwise a suite
+    // can be the first to import e.g. @testing-library/react mid-run, which
+    // triggers a full Vite re-optimize and invalidates the dep URLs other
+    // parallel browser suites are still fetching — surfacing as
+    // "Failed to fetch dynamically imported module .../@testing-library_react.js".
+    optimizeDeps: {
+      include: [
+        "@testing-library/react",
+        "@testing-library/dom",
+        "@testing-library/user-event",
+        "@testing-library/jest-dom",
+        "react",
+        "react-dom",
+        "react-dom/client",
+        "react/jsx-dev-runtime",
+      ],
+    },
     test: {
       globals: true,
       setupFiles: ["./src/test/setup.ts"],


### PR DESCRIPTION
Three page suites intermittently failed to import with "Failed to fetch dynamically imported module .../@testing-library_react.js". Cause: a suite was first to import @testing-library/react mid-run, which triggered a full Vite re-optimize and invalidated the dep URLs other parallel browser suites were still fetching (empty optimized-deps hash).

Pre-bundle the shared test deps via optimizeDeps.include so they are optimized once at startup and never re-discovered mid-run. Test config only; the production vite build is unchanged.