### PR TITLE
fix(security): close SSRF gaps and fail-fast on insecure prod config

### DIFF
--- a/Suspicious/Suspicious/api/serializers/submit.py
+++ b/Suspicious/Suspicious/api/serializers/submit.py
@@ -1,5 +1,6 @@
 # api/serializers/submit.py
 import ipaddress
+import socket
 import zipfile as _zipfile
 from urllib.parse import urlparse
 
@@ -32,27 +33,15 @@ class OptionalContextMixin(serializers.Serializer):
         return context.strip()
 
 
-def _check_no_ssrf_ip(url: str) -> None:
+def _is_blocked_addr(addr: ipaddress._BaseAddress) -> bool:
+    """True if an IP address is private, reserved, or otherwise off-limits.
+
+    Unwraps IPv4-mapped IPv6 (``::ffff:127.0.0.1``) so the mapped IPv4 is
+    evaluated, not the harmless-looking IPv6 wrapper.
     """
-    Reject URLs whose hostname is a private/reserved IP address literal.
-
-    Raises ValueError for blocked addresses. Domain names are not resolved
-    here — DNS-time checks are phase-2 work.
-
-    Blocked: loopback, RFC-1918 private, link-local (169.254.x.x / fe80::),
-             unique-local IPv6 (fc00::/7), multicast, reserved, unspecified,
-             CGNAT (100.64.0.0/10, RFC 6598).
-    """
-    hostname = urlparse(url).hostname  # strips [] from IPv6 literals; None-safe
-    if not hostname:
-        return
-
-    try:
-        addr = ipaddress.ip_address(hostname)
-    except ValueError:
-        return  # hostname is a domain name — pass through
-
-    if (
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+        addr = addr.ipv4_mapped
+    return (
         addr.is_loopback
         or addr.is_private
         or addr.is_link_local
@@ -60,8 +49,84 @@ def _check_no_ssrf_ip(url: str) -> None:
         or addr.is_reserved
         or addr.is_unspecified
         or any(addr in net for net in _BLOCKED_NETWORKS)
-    ):
-        raise ValueError("URL targets a private or reserved address.")
+    )
+
+
+def _looks_like_numeric_host(host: str) -> bool:
+    """True for ambiguous numeric host encodings that HTTP clients resolve to
+    IPv4 but ``ipaddress.ip_address`` rejects as literals — e.g. decimal
+    ``2130706433``, hex ``0x7f000001``, or octal ``0177.0.0.1`` (all 127.0.0.1).
+
+    No legitimate DNS hostname is purely numeric/hex, so treating these as
+    suspicious is safe.
+    """
+    h = host.strip(".")
+    if not h:
+        return False
+    if h.isdigit():                       # packed decimal (e.g. 2130706433)
+        return True
+    if h.lower().startswith("0x"):        # packed hex (e.g. 0x7f000001)
+        return True
+    parts = h.split(".")
+    if len(parts) <= 4:
+        for p in parts:
+            if not p:
+                return True
+            if p.lower().startswith("0x"):               # hex octet
+                return True
+            if p.startswith("0") and p != "0" and p.isdigit():  # octal octet
+                return True
+    return False
+
+
+def _check_no_ssrf_ip(url: str) -> None:
+    """
+    Reject URLs that point at private/reserved addresses, including via DNS.
+
+    Defences:
+      1. IP literals (v4/v6, incl. IPv4-mapped) checked against the block list.
+      2. Ambiguous numeric host encodings (decimal/hex/octal) rejected.
+      3. Domain names are resolved and **every** returned address is checked,
+         so a hostname that resolves to a private/metadata IP is blocked.
+
+    Blocked addresses: loopback, RFC-1918 private, link-local
+    (169.254.x.x / fe80::, covers cloud metadata 169.254.169.254),
+    unique-local IPv6 (fc00::/7), multicast, reserved, unspecified,
+    CGNAT (100.64.0.0/10, RFC 6598).
+
+    Raises ValueError when a blocked target is detected.
+    """
+    hostname = urlparse(url).hostname  # strips [] from IPv6 literals; None-safe
+    if not hostname:
+        return
+
+    # 1. Literal IP address?
+    try:
+        addr = ipaddress.ip_address(hostname)
+    except ValueError:
+        addr = None
+    if addr is not None:
+        if _is_blocked_addr(addr):
+            raise ValueError("URL targets a private or reserved address.")
+        return
+
+    # 2. Ambiguous numeric encodings that aren't valid literals but resolve to IPv4.
+    if _looks_like_numeric_host(hostname):
+        raise ValueError("URL host is an ambiguous numeric address.")
+
+    # 3. Resolve the domain and check every address it maps to (DNS rebinding).
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        return  # unresolvable now — any later fetch fails closed anyway
+    for info in infos:
+        ip = info[4][0]
+        try:
+            resolved = ipaddress.ip_address(ip)
+        except ValueError:
+            continue
+        if _is_blocked_addr(resolved):
+            raise ValueError("URL resolves to a private or reserved address.")
 
 
 class SubmitUrlSerializer(OptionalContextMixin, serializers.Serializer):

--- a/Suspicious/Suspicious/api/tests/test_ssrf_submit.py
+++ b/Suspicious/Suspicious/api/tests/test_ssrf_submit.py
@@ -1,0 +1,78 @@
+"""SSRF guard tests for URL submission.
+
+Covers `_check_no_ssrf_ip` / `SubmitUrlSerializer.validate_url`:
+IP literals, ambiguous numeric encodings, IPv4-mapped IPv6, and
+DNS names that resolve to private/reserved addresses.
+"""
+from django.test import SimpleTestCase
+
+from api.serializers.submit import SubmitUrlSerializer, _check_no_ssrf_ip
+
+
+class CheckNoSsrfIpTests(SimpleTestCase):
+    def assertBlocked(self, url):
+        with self.assertRaises(ValueError, msg=f"{url} should be blocked"):
+            _check_no_ssrf_ip(url)
+
+    def assertAllowed(self, url):
+        try:
+            _check_no_ssrf_ip(url)
+        except ValueError as exc:  # pragma: no cover - failure path
+            self.fail(f"{url} should be allowed, raised: {exc}")
+
+    def test_public_ip_literal_allowed(self):
+        self.assertAllowed("http://8.8.8.8/")
+        self.assertAllowed("https://1.1.1.1/path")
+
+    def test_loopback_and_private_literals_blocked(self):
+        for url in (
+            "http://127.0.0.1/",
+            "http://10.0.0.5/",
+            "http://192.168.1.1/",
+            "http://172.16.0.1/",
+            "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+            "http://[::1]/",                              # IPv6 loopback
+            "http://[fe80::1]/",                          # IPv6 link-local
+        ):
+            self.assertBlocked(url)
+
+    def test_ipv4_mapped_ipv6_loopback_blocked(self):
+        self.assertBlocked("http://[::ffff:127.0.0.1]/")
+
+    def test_numeric_encodings_blocked(self):
+        # All of these resolve to 127.0.0.1 in common HTTP clients.
+        self.assertBlocked("http://2130706433/")    # decimal
+        self.assertBlocked("http://0x7f000001/")    # hex
+        self.assertBlocked("http://0177.0.0.1/")    # octal first octet
+
+    def test_domain_resolving_to_loopback_blocked(self):
+        # localhost resolves to 127.0.0.1 / ::1 deterministically.
+        self.assertBlocked("http://localhost/")
+        self.assertBlocked("http://localhost:8080/admin")
+
+    def test_unresolvable_domain_passes(self):
+        # Fails closed at fetch time; the guard does not raise on NXDOMAIN.
+        self.assertAllowed("http://no-such-host.invalid/")
+
+    def test_no_hostname_passes(self):
+        self.assertAllowed("not-a-url")
+
+
+class SubmitUrlSerializerTests(SimpleTestCase):
+    def test_rejects_loopback(self):
+        s = SubmitUrlSerializer(data={"url": "http://127.0.0.1/"})
+        self.assertFalse(s.is_valid())
+        self.assertIn("url", s.errors)
+
+    def test_rejects_decimal_ip(self):
+        s = SubmitUrlSerializer(data={"url": "http://2130706433/"})
+        self.assertFalse(s.is_valid())
+
+    def test_accepts_public_ip(self):
+        s = SubmitUrlSerializer(data={"url": "http://8.8.8.8/"})
+        self.assertTrue(s.is_valid(), s.errors)
+
+    def test_bare_domain_gets_scheme_then_checked(self):
+        # Bare private host without scheme is still blocked.
+        s = SubmitUrlSerializer(data={"url": "localhost"})
+        self.assertFalse(s.is_valid())

--- a/Suspicious/Suspicious/suspicious/settings.py
+++ b/Suspicious/Suspicious/suspicious/settings.py
@@ -130,6 +130,28 @@ if not DEBUG:
     SESSION_COOKIE_SECURE          = True
     CSRF_COOKIE_SECURE             = True
 
+# Fail fast on insecure configuration so a misconfigured production deploy
+# refuses to start instead of running silently exposed.
+from django.core.exceptions import ImproperlyConfigured  # noqa: E402
+
+if SECRET_KEY in ("", "CHANGE_ME"):
+    raise ImproperlyConfigured(
+        "app.secret_key is unset or still the placeholder 'CHANGE_ME'; "
+        "generate a unique random key."
+    )
+
+if not DEBUG:
+    if "*" in ALLOWED_HOSTS:
+        raise ImproperlyConfigured(
+            "ALLOWED_HOSTS must not contain '*' in production; "
+            "set app.allowed_hosts to explicit hostnames."
+        )
+    if SECRET_KEY.startswith("django-insecure") or len(SECRET_KEY) < 50:
+        raise ImproperlyConfigured(
+            "app.secret_key is too weak for production: drop the "
+            "'django-insecure' prefix and use at least 50 random characters."
+        )
+
 # ---------------------------------------------------------------------------
 # Application definition
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
SSRF (api/serializers/submit.py):
- resolve DNS hostnames and check every resolved address (blocks domain -> private/metadata IP, incl. DNS rebinding)
- reject ambiguous numeric host encodings (decimal/hex/octal)
- unwrap IPv4-mapped IPv6 before evaluating
- add test_ssrf_submit (11 cases)

Settings hardening (suspicious/settings.py):
- refuse to boot if SECRET_KEY is empty/'CHANGE_ME'
- in production (DEBUG off), refuse '*' in ALLOWED_HOSTS and reject weak 'django-insecure'/short secret keys