### PR TITLE
feat(vault): grant UI write to integration secrets in provision policy

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -145,6 +145,81 @@ make create-certs
 
 ---
 
+## Secrets & Vault
+
+### Principles
+
+Configuration is split into three tiers — knowing which tier owns a value tells you where to set it:
+
+| Tier | Holds | Source of truth |
+|------|-------|-----------------|
+| **Bootstrap** | Ports, image versions, Vault AppRole IDs, DB/MinIO bootstrap creds | `deployment/.env` |
+| **Secrets** | API keys, passwords, Django secret key | HashiCorp Vault (KV v2 at `suspicious/<dotted-key>`) |
+| **Runtime config** | Non-secret app settings (branding, integration URLs, …) | Database, seeded from `settings.json` |
+
+Key rules:
+
+* **`settings.json` is the dev/CI fallback, read-only at runtime.** Leave `VAULT_ADDR` unset and secrets are read straight from `settings.json` — no Vault needed for tests or local dev.
+* **`VAULT_ADDR` set ⇒ Vault is the secret store.** Real secrets are read from Vault and overlaid onto `settings.json` paths at boot.
+* **Editing connector secrets from the Settings UI requires Vault.** Admins can set/rotate `integrations.*` secrets (cortex, thehive, misp, watcher) in the UI; the write goes straight to Vault. With no Vault the UI save returns **409 secret store not configured** — set those secrets in `settings.json` instead.
+* The AppRole policy written by `make provision-vault` already allows the UI to write integration secrets; everything else stays read-only.
+
+Full secret map and details: [`VAULT.md`](VAULT.md).
+
+### Bring up Vault (copy-paste)
+
+Run from `deployment/`. Vault uses file storage and starts **sealed** on every boot — re-run the unseal step after each restart.
+
+**1. Enable Vault in `.env`** (uncomment / add):
+
+```bash
+VAULT_ADDR=http://vault:8200
+VAULT_PORT=8200
+VAULT_PATH=./vault
+```
+
+**2. Start the stack, then initialise + unseal Vault:**
+
+```bash
+make up
+export VAULT_ADDR=http://127.0.0.1:8200
+vault operator init        # FIRST BOOT ONLY — record unseal keys + root token SECURELY
+vault operator unseal      # repeat with the threshold number of keys
+export VAULT_TOKEN=<root-token>
+```
+
+**3. Provision KV + AppRole** (writes `VAULT_ROLE_ID` / `VAULT_SECRET_ID` into `.env`):
+
+```bash
+make provision-vault
+```
+
+**4. Seed the secrets** (values come from your environment only — never a committed file):
+
+```bash
+export SECRET_KEY=...            # required
+export DB_PASSWORD=...           # required
+export CORTEX_API_KEY=...        # required
+export CORTEX_WEBHOOK_SECRET=... # required
+export S3_SECRET_KEY=...         # required
+# optional — export only those you use:
+export WATCHER_API_KEY=... THEHIVE_API_KEY=... MISP_PRIMARY_API_KEY=... \
+       MISP_SECONDARY_API_KEY=... LDAP_BIND_PASSWORD=... OIDC_CLIENT_SECRET=... SMTP_PASSWORD=...
+make seed-vault-secrets
+```
+
+**5. Migrate + seed runtime config, then restart:**
+
+```bash
+make deploy
+```
+
+The app now reads secrets from Vault and runtime config from the DB. Later restarts only need the unseal step (2).
+
+> **Rotation:** update the value in Vault (`vault kv put suspicious/<dotted-key> value=...`), then restart the app containers so they re-read it at boot.
+
+---
+
 ## Security Notes
 
 * `.env` **must never be committed** — it contains secrets.
@@ -165,6 +240,8 @@ make create-certs
 | Start services        | `make up`           |
 | Stop services         | `make down`         |
 | Deploy updates        | `make deploy`       |
+| Provision Vault       | `make provision-vault` |
+| Seed Vault secrets    | `make seed-vault-secrets` |
 | Run migrations        | `make migrate`      |
 | Backup database       | `make backup`       |
 | Create superuser      | `make superuser`    |

--- a/deployment/VAULT.md
+++ b/deployment/VAULT.md
@@ -89,9 +89,9 @@ DB. Restarting the stack later requires only re-unsealing Vault (step 3).
 ## Editing connector secrets from the UI
 
 Admins can set/rotate connector secrets (`integrations.*` — cortex, thehive,
-misp, watcher) from the Settings UI, which writes straight to Vault. The default
-`suspicious-read` AppRole policy is **read-only**, so this is opt-in: widen the
-policy to allow writing the integration secret paths before using the feature.
+misp, watcher) from the Settings UI, which writes straight to Vault.
+`make provision-vault` already grants this — the `suspicious-read` policy it
+writes includes scoped create/update on the integration secret paths:
 
 ```hcl
 path "suspicious/data/integrations/*" {
@@ -99,9 +99,8 @@ path "suspicious/data/integrations/*" {
 }
 ```
 
-Add this stanza to the `suspicious-read` policy (`make provision-vault` writes
-the read-only baseline; re-`vault policy write` with the wider rules, or edit the
-policy in place). Behaviour without the widening:
+Everything else stays read-only. If you tightened the policy by hand and removed
+this stanza, the UI feature stops working as follows:
 
 - **`create`/`update` missing** → UI save returns **502 secret store write
   failed** (Vault rejects the write).

--- a/deployment/scripts/provision-vault.sh
+++ b/deployment/scripts/provision-vault.sh
@@ -14,6 +14,10 @@ vault secrets enable -path=suspicious kv-v2 2>/dev/null || true
 vault policy write suspicious-read - <<'EOF'
 path "suspicious/data/*"     { capabilities = ["read"] }
 path "suspicious/metadata/*" { capabilities = ["read", "list"] }
+# Connector secret editing from the Settings UI writes integration secrets
+# straight to Vault. Scoped create/update so admins can set/rotate them;
+# boot-critical and non-connector secrets stay read-only above.
+path "suspicious/data/integrations/*" { capabilities = ["create", "update", "read"] }
 EOF
 
 vault auth enable approle 2>/dev/null || true


### PR DESCRIPTION
The suspicious-read AppRole policy was read-only, so editing connector secrets (integrations.* — cortex/thehive/misp/watcher) from the Settings UI failed with 502 even when Vault was configured. Add a scoped create/update/read stanza on suspicious/data/integrations/* to provision-vault.sh so the feature works out of the box; everything else stays read-only.

Document the Vault bring-up as a copy-paste runbook in deployment/README.md (principles + step-by-step) and update VAULT.md to reflect the widened baseline policy.