### PR TITLE
fix(vault): run vault CLI inside the container in provisioning scripts

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -178,14 +178,13 @@ VAULT_PORT=8200
 VAULT_PATH=./vault
 ```
 
-**2. Start the stack, then initialise + unseal Vault:**
+**2. Start the stack, then initialise + unseal Vault.** Vault runs as a Compose service, so run its CLI inside the container:
 
 ```bash
 make up
-export VAULT_ADDR=http://127.0.0.1:8200
-vault operator init        # FIRST BOOT ONLY — record unseal keys + root token SECURELY
-vault operator unseal      # repeat with the threshold number of keys
-export VAULT_TOKEN=<root-token>
+docker compose --env-file .env exec vault vault operator init    # FIRST BOOT ONLY — record unseal keys + root token SECURELY
+docker compose --env-file .env exec vault vault operator unseal   # repeat with the threshold number of keys
+export VAULT_TOKEN=<root-token>                                   # used by make provision-vault / seed-vault-secrets
 ```
 
 **3. Provision KV + AppRole** (writes `VAULT_ROLE_ID` / `VAULT_SECRET_ID` into `.env`):

--- a/deployment/VAULT.md
+++ b/deployment/VAULT.md
@@ -49,16 +49,18 @@ boot, so the unseal step is mandatory.
 1. **`make init`** — network, TLS certs, config files (creates `settings.json`
    from the sample if absent).
 2. **`make up`** — start the stack (including the Vault container).
-3. **Initialise + unseal Vault** (first boot only initialises):
+3. **Initialise + unseal Vault** (first boot only initialises). Vault runs as a
+   Compose service, so run its CLI inside the container:
    ```bash
-   vault operator init        # record the unseal keys + root token SECURELY
-   vault operator unseal      # repeat with the threshold number of keys
+   docker compose --env-file .env exec vault vault operator init    # record the unseal keys + root token SECURELY
+   docker compose --env-file .env exec vault vault operator unseal   # repeat with the threshold number of keys
    ```
-   On every subsequent restart Vault comes up sealed — re-run `vault operator
-   unseal` after each `make up`/restart.
-4. **Export the root token** for the provisioning + seeding steps:
+   On every subsequent restart Vault comes up sealed — re-run the `operator
+   unseal` command after each `make up`/restart.
+4. **Export the root token** for the provisioning + seeding steps (the `make`
+   targets run the vault CLI inside the container for you, so only the token is
+   needed on the host):
    ```bash
-   export VAULT_ADDR=http://127.0.0.1:8200
    export VAULT_TOKEN=<root-token>
    ```
 5. **`make provision-vault`** — enables KV v2 + AppRole, writes the

--- a/deployment/scripts/provision-vault.sh
+++ b/deployment/scripts/provision-vault.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
 # Provision Vault for Suspicious: enable KV v2 at suspicious/, write the
 # suspicious-read AppRole policy, create the AppRole, and emit role_id /
-# secret_id into deployment/.env. Requires VAULT_ADDR + VAULT_TOKEN (root or
-# an admin token) in the environment.
+# secret_id into deployment/.env. Vault runs as a Docker Compose service, so
+# every vault command is executed inside that container. Requires VAULT_TOKEN
+# (root or admin) in the environment.
 set -euo pipefail
 
-: "${VAULT_ADDR:?set VAULT_ADDR (e.g. http://127.0.0.1:8200)}"
 : "${VAULT_TOKEN:?set VAULT_TOKEN (root/admin) for provisioning}"
-export VAULT_ADDR VAULT_TOKEN
+export VAULT_TOKEN
+
+DEPLOY_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$DEPLOY_DIR"           # so `docker compose` resolves .env + COMPOSE_FILE
+ENV_FILE="$DEPLOY_DIR/.env"
+
+VAULT_SVC="${VAULT_SVC:-vault}"
+# Run the vault CLI inside the running Vault container (no host CLI required).
+vault() {
+  docker compose --env-file .env exec -T \
+    -e VAULT_TOKEN -e VAULT_ADDR=http://127.0.0.1:8200 \
+    "$VAULT_SVC" vault "$@"
+}
 
 vault secrets enable -path=suspicious kv-v2 2>/dev/null || true
 
@@ -27,7 +39,6 @@ vault write auth/approle/role/suspicious \
 ROLE_ID=$(vault read -field=role_id auth/approle/role/suspicious/role-id)
 SECRET_ID=$(vault write -f -field=secret_id auth/approle/role/suspicious/secret-id)
 
-ENV_FILE="$(cd "$(dirname "$0")/.." && pwd)/.env"
 sed -i '/^VAULT_ROLE_ID=/d;/^VAULT_SECRET_ID=/d' "$ENV_FILE" 2>/dev/null || true
 {
   echo "VAULT_ROLE_ID=${ROLE_ID}"

--- a/deployment/scripts/seed-vault-secrets.sh
+++ b/deployment/scripts/seed-vault-secrets.sh
@@ -1,16 +1,26 @@
 #!/usr/bin/env bash
 # Seed Suspicious secrets into Vault (KV v2 at suspicious/<dotted-key>, field
-# "value"). Requires VAULT_ADDR + VAULT_TOKEN. Secret values come from the
+# "value"). Vault runs as a Docker Compose service, so vault commands execute
+# inside that container. Requires VAULT_TOKEN. Secret values come from the
 # operator's environment (export them before running) — never from a committed
 # file. Unset optional secrets are written empty.
 set -euo pipefail
-: "${VAULT_ADDR:?set VAULT_ADDR}"
 : "${VAULT_TOKEN:?set VAULT_TOKEN (root/admin) for seeding}"
-export VAULT_ADDR VAULT_TOKEN
+export VAULT_TOKEN
+
+cd "$(cd "$(dirname "$0")/.." && pwd)"   # so `docker compose` resolves .env + COMPOSE_FILE
+
+VAULT_SVC="${VAULT_SVC:-vault}"
+# Run the vault CLI inside the running Vault container (no host CLI required).
+vault() {
+  docker compose --env-file .env exec -T \
+    -e VAULT_TOKEN -e VAULT_ADDR=http://127.0.0.1:8200 \
+    "$VAULT_SVC" vault "$@"
+}
 
 put() { vault kv put "suspicious/$1" value="$2" >/dev/null && echo "  wrote suspicious/$1"; }
 
-echo "Seeding secrets into Vault at ${VAULT_ADDR} ..."
+echo "Seeding secrets into Vault ..."
 put app.secret_key                                "${SECRET_KEY:?export SECRET_KEY}"
 put database.password                             "${DB_PASSWORD:?export DB_PASSWORD}"
 put integrations.cortex.api_key                   "${CORTEX_API_KEY:?export CORTEX_API_KEY}"


### PR DESCRIPTION
provision-vault.sh and seed-vault-secrets.sh called the `vault` binary on the host, but Vault runs only as a Docker Compose service, so the scripts failed with `vault: command not found` (make exit 127). Wrap the vault command to `docker compose exec -T vault vault ...`, dropping the host VAULT_ADDR requirement (the container provides its own); only VAULT_TOKEN is needed on the host now.

Update the README and VAULT.md bring-up runbooks so `operator init` / `operator unseal` are also run inside the container.