### PR TITLE
feat(vault): auto-unseal Vault at make up / deploy from host keys file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ mainlog
 # Environment
 *.env
 db_suspicious.env
+# Vault unseal keys (host-only secret; never commit)
+deployment/vault/unseal.keys
 *.old
 chromadb
 *.sqlite

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -35,7 +35,7 @@ endef
         backup-db restore-db \
         logs status shell db-shell \
         create-certs network clean prune \
-        check-secrets check-updates provision-vault seed-vault-secrets
+        check-secrets check-updates provision-vault seed-vault-secrets unseal
 
 # ---------------------------------------------------------------------------
 # Help
@@ -57,6 +57,7 @@ help:
 	@echo "  install-hooks    Configure git core.hooksPath -> .githooks (commit-msg validator)"
 	@echo "  provision-vault  Enable KV+AppRole in Vault, write role/secret IDs to .env"
 	@echo "  seed-vault-secrets  Write secret env vars into Vault KV (suspicious/<key>)"
+	@echo "  unseal           Unseal Vault from vault/unseal.keys (auto-run by up/deploy)"
 	@echo "  down             Stop and remove containers (data preserved)"
 	@echo "  restart          Restart all running services"
 	@echo "  build            Build local images"
@@ -159,7 +160,14 @@ up: check-secrets
 	@$(SCRIPTS)/replace-tls.sh
 	@echo "Starting services…"
 	@$(COMPOSE) up -d --remove-orphans
+	@$(SCRIPTS)/unseal-vault.sh
 	$(OK) "Services started."
+
+## Unseal the Vault container from vault/unseal.keys (idempotent; no-op if
+## already unsealed or no keys file present). Auto-run by `up` and `deploy`.
+unseal:
+	$(call require_script,$(SCRIPTS)/unseal-vault.sh)
+	@$(SCRIPTS)/unseal-vault.sh
 
 ## Stop all containers (volumes and data preserved)
 down:

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -178,14 +178,27 @@ VAULT_PORT=8200
 VAULT_PATH=./vault
 ```
 
-**2. Start the stack, then initialise + unseal Vault.** Vault runs as a Compose service, so run its CLI inside the container:
+**2. Start the stack, then initialise Vault.** Vault runs as a Compose service, so run its CLI inside the container:
 
 ```bash
 make up
-docker compose --env-file .env exec vault vault operator init    # FIRST BOOT ONLY — record unseal keys + root token SECURELY
-docker compose --env-file .env exec vault vault operator unseal   # repeat with the threshold number of keys
+docker compose --env-file .env exec vault vault operator init    # FIRST BOOT ONLY — prints unseal keys + root token; record them SECURELY
 export VAULT_TOKEN=<root-token>                                   # used by make provision-vault / seed-vault-secrets
 ```
+
+Save the unseal keys (one per line) to `vault/unseal.keys` so every later boot
+unseals automatically — `make up` and `make deploy` run `make unseal` for you:
+
+```bash
+install -m 600 /dev/null vault/unseal.keys   # then paste one unseal key per line
+make unseal                                  # unseal now (idempotent)
+```
+
+> `vault/unseal.keys` is gitignored and host-only. Storing unseal keys beside
+> Vault weakens the seal (a stolen disk can be unsealed) — fine for this
+> single-host deployment; use Vault auto-unseal (cloud KMS / transit) for
+> production. Without the file, Vault stays sealed and you unseal manually:
+> `docker compose --env-file .env exec vault vault operator unseal`.
 
 **3. Provision KV + AppRole** (writes `VAULT_ROLE_ID` / `VAULT_SECRET_ID` into `.env`):
 

--- a/deployment/VAULT.md
+++ b/deployment/VAULT.md
@@ -53,10 +53,17 @@ boot, so the unseal step is mandatory.
    Compose service, so run its CLI inside the container:
    ```bash
    docker compose --env-file .env exec vault vault operator init    # record the unseal keys + root token SECURELY
-   docker compose --env-file .env exec vault vault operator unseal   # repeat with the threshold number of keys
    ```
-   On every subsequent restart Vault comes up sealed — re-run the `operator
-   unseal` command after each `make up`/restart.
+   Save the unseal keys (one per line) to `deployment/vault/unseal.keys`
+   (gitignored, `chmod 600`). Vault comes up **sealed** on every boot, but
+   `make up` and `make deploy` run `make unseal`, which reads that file and
+   unseals automatically — no manual step after the first init. To unseal on
+   demand: `make unseal`. Without the keys file, unseal by hand:
+   `docker compose --env-file .env exec vault vault operator unseal`.
+
+   > Security: unseal keys on the host weaken the seal (a stolen disk can be
+   > unsealed). Acceptable for a single-host deployment; use Vault auto-unseal
+   > (cloud KMS / transit Vault) for production.
 4. **Export the root token** for the provisioning + seeding steps (the `make`
    targets run the vault CLI inside the container for you, so only the token is
    needed on the host):

--- a/deployment/scripts/deploy.sh
+++ b/deployment/scripts/deploy.sh
@@ -32,6 +32,11 @@ bash "${SCRIPTS}/check-secrets.sh" .env
 bash "${SCRIPTS}/check-network.sh"
 ok "Pre-flight passed"
 
+# ── 1b. Unseal Vault (before any container reads secrets from it) ─────────
+step "Unsealing Vault"
+bash "${SCRIPTS}/unseal-vault.sh"
+ok "Vault unseal checked"
+
 # ── 2. Pull images ────────────────────────────────────────────────────────
 step "Pulling latest images"
 $COMPOSE pull suspicious suspicious_ui feeder

--- a/deployment/scripts/unseal-vault.sh
+++ b/deployment/scripts/unseal-vault.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Unseal the Vault container using operator unseal keys stored on the host.
+#
+# Idempotent and safe to run at every boot: it no-ops when Vault is already
+# unsealed, when Vault is unreachable, or when no keys file is present — so it
+# never blocks `make up` on an uninitialised or Vault-less setup.
+#
+# SECURITY: the unseal keys live on the same host as Vault
+# (vault/unseal.keys, gitignored, chmod 600). This trades away part of the
+# seal's protection — whoever can read the file can unseal Vault. Acceptable
+# for a single-host dev/staging deployment; for production use Vault
+# auto-unseal backed by a cloud KMS or a transit Vault instead.
+set -euo pipefail
+
+DEPLOY_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$DEPLOY_DIR"           # so `docker compose` resolves .env + COMPOSE_FILE
+KEYS_FILE="${VAULT_UNSEAL_KEYS_FILE:-$DEPLOY_DIR/vault/unseal.keys}"
+VAULT_SVC="${VAULT_SVC:-vault}"
+
+# Run the vault CLI inside the running Vault container (no host CLI required).
+vault() {
+  docker compose --env-file .env exec -T \
+    -e VAULT_ADDR=http://127.0.0.1:8200 "$VAULT_SVC" vault "$@"
+}
+
+# Echo the seal state: unsealed | sealed | down.
+# `vault status` exits 0 when unsealed, 2 when sealed, other when unreachable.
+seal_state() {
+  if vault status >/dev/null 2>&1; then
+    echo unsealed
+  else
+    case $? in
+      2) echo sealed ;;
+      *) echo down ;;
+    esac
+  fi
+}
+
+# Wait up to ~30s for the container to answer at all (it may still be booting).
+for _ in $(seq 1 30); do
+  [ "$(seal_state)" != down ] && break
+  sleep 1
+done
+
+case "$(seal_state)" in
+  unsealed)
+    echo "Vault already unsealed."
+    exit 0 ;;
+  down)
+    echo "WARN: Vault not reachable; skipping unseal." >&2
+    exit 0 ;;
+esac
+
+if [ ! -f "$KEYS_FILE" ]; then
+  echo "WARN: no unseal keys at $KEYS_FILE — Vault left sealed." >&2
+  echo "      Run 'make provision-vault' prerequisites: 'vault operator init'," >&2
+  echo "      then write the unseal keys (one per line) to that file." >&2
+  exit 0
+fi
+
+echo "Unsealing Vault with keys from $KEYS_FILE …"
+while IFS= read -r line; do
+  key="${line%%#*}"                         # strip inline comments
+  key="$(printf '%s' "$key" | tr -d '[:space:]')"
+  [ -z "$key" ] && continue
+  vault operator unseal "$key" >/dev/null || true
+  [ "$(seal_state)" = unsealed ] && break
+done < "$KEYS_FILE"
+
+if [ "$(seal_state)" = unsealed ]; then
+  echo "Vault unsealed."
+else
+  echo "ERROR: Vault still sealed after applying keys from $KEYS_FILE" >&2
+  exit 1
+fi


### PR DESCRIPTION
Vault boots sealed on every restart, which blocked make up / deploy and required a manual operator unseal each time. Add scripts/unseal-vault.sh: an idempotent unsealer that waits for the Vault container, no-ops if already unsealed / unreachable / no keys file, and otherwise feeds the keys from deployment/vault/unseal.keys via the container CLI.

Wire it into `make up` (after compose up) and deploy.sh (after pre-flight, before any container reads secrets), and expose a standalone `make unseal`.

The keys file is host-only and gitignored; storing unseal keys beside Vault weakens the seal, so the script header and docs flag it as dev/single-host only (use KMS/transit auto-unseal for production). Update README + VAULT.md runbooks accordingly.