### PR TITLE
fix(ui): pre-bundle axios to stop a vi.mock race in browser-mode tests

### DIFF
--- a/suspicious-ui/vitest.config.ts
+++ b/suspicious-ui/vitest.config.ts
@@ -20,6 +20,7 @@ export default mergeConfig(
         "react-dom",
         "react-dom/client",
         "react/jsx-dev-runtime",
+        "axios",
         "@mui/icons-material/BlockOutlined",
         "@mui/icons-material/CheckCircleOutlined",
         "@mui/icons-material/EmailOutlined",


### PR DESCRIPTION
Every settings/submissions/auth test file mocks @/api/client, which wraps axios — but axios wasn't in optimizeDeps.include like the other shared test deps (react, testing-library, etc). When some suite was first to import it mid-run, Vite's dep re-optimization invalidated in-flight module fetches for parallel suites, occasionally handing features/settings/__tests__/api.test.ts the real unmocked axios methods instead of the vi.fn() mocks (surfaced in CI as "mockGet.mockResolvedValueOnce is not a function"). Pre-bundling axios closes the same race the existing include list was added for.