### PR TITLE
fix: repair broken opentelemetry/beautifulsoup4 pins from unpaired Dependabot merges

### DIFF
--- a/Suspicious/requirements.txt
+++ b/Suspicious/requirements.txt
@@ -83,8 +83,8 @@ hvac==2.3.0
 # Observability
 # 1.28.0+ needed: opentelemetry-proto pins protobuf<5 below that, which
 # conflicts with the >=5.29.6 fix for PYSEC-2026-1805.
-opentelemetry-sdk==1.28.0
-opentelemetry-instrumentation-django==0.49b0
-opentelemetry-instrumentation-requests==0.49b0
-opentelemetry-instrumentation-celery==0.49b0
+opentelemetry-sdk==1.44.0
+opentelemetry-instrumentation-django==0.65b0
+opentelemetry-instrumentation-requests==0.65b0
+opentelemetry-instrumentation-celery==0.65b0
 opentelemetry-exporter-otlp-proto-http==1.44.0

--- a/email-feeder/requirements.txt
+++ b/email-feeder/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.15.0
+beautifulsoup4==4.13.5
 requests==2.34.2
 python-dateutil==2.9.0.post0
 minio==7.2.20
@@ -19,4 +19,4 @@ python-json-logger==4.1.0
 # conflicts with the >=5.29.6 fix for PYSEC-2026-1805.
 opentelemetry-sdk==1.44.0
 opentelemetry-exporter-otlp-proto-http==1.44.0
-opentelemetry-instrumentation-requests==0.49b0
+opentelemetry-instrumentation-requests==0.65b0


### PR DESCRIPTION
## Summary
- Merging #194 (opentelemetry-exporter-otlp-proto-http → 1.44.0 in /Suspicious) without a matching opentelemetry-sdk bump left `Suspicious/requirements.txt` unresolvable (sdk was still pinned 1.28.0, exporter needs sdk>=1.44.0).
- Bumping opentelemetry-sdk to 1.44.0 (both /Suspicious and /email-feeder) also requires opentelemetry-semantic-conventions 0.65b0, which the still-pinned 0.49b0 instrumentation packages (django/requests/celery) don't support — bumped those too.
- #193 bumped beautifulsoup4 to 4.15.0 in /email-feeder, but extract-msg 0.55.0 caps it at `<4.14`. Reverted to 4.13.5 (highest compatible release).

All three broke `docker build` outright, not just tests. Verified locally:
- `docker build Suspicious/` — now succeeds
- `docker build email-feeder/` — now succeeds
- `docker build Analyzers/AIMailAnalyzer/` — unaffected, still succeeds

## Test plan
- [x] Local docker build of `suspicious`, `suspicious-feeder` images succeeds
- [ ] CI docker-build / backend-test / feeder-test jobs pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)