### PR TITLE
fix(ci): stop sbom-action from failing on release-asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,12 @@ jobs:
           image: ${{ matrix.image }}@${{ steps.build.outputs.digest }}
           format: spdx-json
           output-file: sbom-${{ matrix.name }}.spdx.json
+          # Job only has contents:read; release-asset upload needs
+          # contents:write and fails with "Resource not accessible by
+          # integration". SBOM is already uploaded as a workflow artifact
+          # below, so skip the redundant release attach instead of widening
+          # permissions.
+          upload-release-assets: false
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Every tag push logged `Error: Resource not accessible by integration` from the SBOM step in `release.yml`.
- Root cause: `anchore/sbom-action` defaults `upload-release-assets` to `true`, which needs `contents: write`; the `build-push` job intentionally only grants `contents: read`.
- The SBOM is already uploaded as a workflow artifact in the very next step, so the release attach is redundant. Set `upload-release-assets: false` instead of widening job permissions.

## Test plan
- [ ] Push a `v*` tag (or re-run the workflow) and confirm the SBOM step no longer errors
- [ ] Confirm the `sbom-<name>` workflow artifact still gets uploaded