### PR TITLE
fix(ui): pre-bundle react-joyride to stop a vi.mock race in browser tests

### DIFF
--- a/suspicious-ui/vitest.config.ts
+++ b/suspicious-ui/vitest.config.ts
@@ -21,6 +21,7 @@ export default mergeConfig(
         "react-dom/client",
         "react/jsx-dev-runtime",
         "axios",
+        "react-joyride",
         "@mui/icons-material/BlockOutlined",
         "@mui/icons-material/CheckCircleOutlined",
         "@mui/icons-material/EmailOutlined",


### PR DESCRIPTION
## Summary
- CI was flaking with `TypeError: mockGet.mockResolvedValueOnce is not a function` in `src/features/settings/__tests__/api.test.ts` (and same-shaped failures for mockPost/mockPatch/mockDelete).
- Same race class fixed in 8596678 for axios: `HelpTourProvider` (mounted app-wide in `AppLayout`) imports `react-joyride`, but it was never added to `vitest.config.ts`'s `optimizeDeps.include`. The recent 3.1.0 → 3.2.0 bump (#209) changed enough of its internals to trigger a mid-run Vite dependency re-optimize, which invalidates in-flight module fetches for other parallel browser-mode suites — handing `api.test.ts` the real unmocked axios methods instead of the `vi.fn()` mocks.
- Fix: add `react-joyride` to the pre-bundled dep list, same pattern as `axios`/testing-library/MUI icons.

## Test plan
- [ ] CI frontend test job passes with no `mockResolvedValueOnce is not a function` flakes