### PR TITLE
fix(mail_feeder): cap preview render height, add retention sweep

### DIFF
--- a/Suspicious/Suspicious/mail_feeder/management/commands/purge_mail_previews.py
+++ b/Suspicious/Suspicious/mail_feeder/management/commands/purge_mail_previews.py
@@ -1,0 +1,55 @@
+"""
+Delete objects from the `mail-previews` MinIO bucket by age and/or size.
+
+Deliberately does not touch Mail.preview_object_key — see
+mail_feeder.utils.email_preview.retention for why a deleted preview is
+safe to leave "pointed at" (MailPreviewView lazily re-renders on next
+view instead of erroring).
+
+Usage:
+    python manage.py purge_mail_previews --older-than-days 90
+    python manage.py purge_mail_previews --min-size-mb 15
+    python manage.py purge_mail_previews --older-than-days 90 --min-size-mb 15
+    python manage.py purge_mail_previews --min-size-mb 15 --dry-run
+"""
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+
+from mail_feeder.utils.email_preview.retention import purge_mail_previews
+
+
+class Command(BaseCommand):
+    help = "Delete mail-preview objects from MinIO by age and/or size."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("--older-than-days", type=int, default=None)
+        parser.add_argument("--min-size-mb", type=float, default=None)
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, **opts) -> None:
+        older_than_days = opts["older_than_days"]
+        min_size_mb = opts["min_size_mb"]
+        dry_run = opts["dry_run"]
+
+        if older_than_days is None and min_size_mb is None:
+            raise CommandError(
+                "Provide --older-than-days and/or --min-size-mb — refusing "
+                "to run with no criteria (that would match every object)."
+            )
+
+        result = purge_mail_previews(
+            older_than_days=older_than_days,
+            min_size_mb=min_size_mb,
+            dry_run=dry_run,
+        )
+
+        verb = "Would delete" if dry_run else "Deleted"
+        self.stdout.write(self.style.SUCCESS(
+            f"{verb} {result.deleted_count} object(s), "
+            f"{result.deleted_bytes / (1024 * 1024):.1f} MB."
+        ))
+        if result.errors:
+            self.stdout.write(self.style.WARNING(
+                f"{len(result.errors)} object(s) failed to delete (see logs)."
+            ))

--- a/Suspicious/Suspicious/mail_feeder/tests/test_eml2png_render_limits.py
+++ b/Suspicious/Suspicious/mail_feeder/tests/test_eml2png_render_limits.py
@@ -1,0 +1,44 @@
+"""Tests for the render-height cap and post-render size guard.
+
+Root cause of a production incident: wkhtmltoimage renders the full page
+height with no bound, so a pathologically tall email body produced
+multi-hundred-MB to multi-GB preview PNGs. `_render_html_to_png` now caps
+the rendered height and drops (never stores) any render that still comes
+out oversized.
+"""
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from mail_feeder.utils.email_preview.eml2png_renderer import (
+    _MAX_PNG_BYTES,
+    _MAX_RENDER_HEIGHT_PX,
+    Eml2PngRenderer,
+)
+
+
+class RenderHeightCapTests(SimpleTestCase):
+    def test_height_option_passed_to_imgkit(self):
+        renderer = Eml2PngRenderer()
+        renderer._imgkit_available = True
+        with mock.patch("imgkit.from_string", return_value=b"PNGDATA") as mocked:
+            out = renderer._render_html_to_png("<p>hi</p>")
+        self.assertEqual(out, b"PNGDATA")
+        _, kwargs = mocked.call_args
+        self.assertEqual(kwargs["options"]["height"], str(_MAX_RENDER_HEIGHT_PX))
+
+    def test_oversized_render_is_dropped_not_stored(self):
+        renderer = Eml2PngRenderer()
+        renderer._imgkit_available = True
+        oversized = b"x" * (_MAX_PNG_BYTES + 1)
+        with mock.patch("imgkit.from_string", return_value=oversized):
+            out = renderer._render_html_to_png("<p>hi</p>")
+        self.assertIsNone(out)
+
+    def test_render_at_or_under_limit_is_kept(self):
+        renderer = Eml2PngRenderer()
+        renderer._imgkit_available = True
+        at_limit = b"x" * _MAX_PNG_BYTES
+        with mock.patch("imgkit.from_string", return_value=at_limit):
+            out = renderer._render_html_to_png("<p>hi</p>")
+        self.assertEqual(out, at_limit)

--- a/Suspicious/Suspicious/mail_feeder/tests/test_retention.py
+++ b/Suspicious/Suspicious/mail_feeder/tests/test_retention.py
@@ -1,0 +1,105 @@
+"""Unit tests for the mail-preview MinIO bucket sweep.
+
+All MinIO access is mocked — these tests exercise the age/size matching
+logic and the "never touch the Mail row" contract, never a live bucket.
+"""
+from datetime import timedelta
+from unittest import mock
+
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from mail_feeder.utils.email_preview.retention import purge_mail_previews
+
+
+def _fake_object(name, size, last_modified):
+    obj = mock.MagicMock()
+    obj.object_name = name
+    obj.size = size
+    obj.last_modified = last_modified
+    return obj
+
+
+class PurgeMailPreviewsTest(SimpleTestCase):
+    def _client(self, objects):
+        client = mock.MagicMock()
+        client.bucket_exists.return_value = True
+        client.list_objects.return_value = objects
+        return client
+
+    def test_requires_at_least_one_criterion(self):
+        with self.assertRaises(ValueError):
+            purge_mail_previews()
+
+    def test_deletes_objects_older_than_cutoff(self):
+        now = timezone.now()
+        old = _fake_object("1.png", 1000, now - timedelta(days=100))
+        recent = _fake_object("2.png", 1000, now - timedelta(days=1))
+        client = self._client([old, recent])
+
+        with mock.patch(
+            "mail_feeder.utils.email_preview.retention.get_s3_client",
+            return_value=client,
+        ):
+            result = purge_mail_previews(older_than_days=90)
+
+        client.remove_object.assert_called_once_with("mail-previews", "1.png")
+        self.assertEqual(result.deleted_count, 1)
+        self.assertEqual(result.deleted_bytes, 1000)
+
+    def test_deletes_objects_over_size_regardless_of_age(self):
+        now = timezone.now()
+        big_recent = _fake_object("1.png", 20 * 1024 * 1024, now)
+        small_recent = _fake_object("2.png", 1000, now)
+        client = self._client([big_recent, small_recent])
+
+        with mock.patch(
+            "mail_feeder.utils.email_preview.retention.get_s3_client",
+            return_value=client,
+        ):
+            result = purge_mail_previews(min_size_mb=15)
+
+        client.remove_object.assert_called_once_with("mail-previews", "1.png")
+        self.assertEqual(result.deleted_count, 1)
+
+    def test_dry_run_never_calls_remove_object(self):
+        now = timezone.now()
+        old = _fake_object("1.png", 1000, now - timedelta(days=100))
+        client = self._client([old])
+
+        with mock.patch(
+            "mail_feeder.utils.email_preview.retention.get_s3_client",
+            return_value=client,
+        ):
+            result = purge_mail_previews(older_than_days=90, dry_run=True)
+
+        client.remove_object.assert_not_called()
+        self.assertEqual(result.deleted_count, 1)
+
+    def test_missing_bucket_is_a_noop(self):
+        client = mock.MagicMock()
+        client.bucket_exists.return_value = False
+
+        with mock.patch(
+            "mail_feeder.utils.email_preview.retention.get_s3_client",
+            return_value=client,
+        ):
+            result = purge_mail_previews(older_than_days=90)
+
+        client.list_objects.assert_not_called()
+        self.assertEqual(result.deleted_count, 0)
+
+    def test_delete_failure_is_recorded_not_raised(self):
+        now = timezone.now()
+        old = _fake_object("1.png", 1000, now - timedelta(days=100))
+        client = self._client([old])
+        client.remove_object.side_effect = Exception("network down")
+
+        with mock.patch(
+            "mail_feeder.utils.email_preview.retention.get_s3_client",
+            return_value=client,
+        ):
+            result = purge_mail_previews(older_than_days=90)
+
+        self.assertEqual(result.deleted_count, 0)
+        self.assertEqual(result.errors, ["1.png"])

--- a/Suspicious/Suspicious/mail_feeder/utils/email_preview/eml2png_renderer.py
+++ b/Suspicious/Suspicious/mail_feeder/utils/email_preview/eml2png_renderer.py
@@ -39,6 +39,23 @@ _DEFAULT_PREVIEW_BUCKET = "mail-previews"
 
 _RENDER_WIDTH_PX = 900
 
+# wkhtmltoimage renders the *entire* page as one image with no pagination —
+# an email body with pathological height (a long forwarded/quoted chain, or
+# a hostile HTML payload designed to bloat the render) produces an
+# arbitrarily tall PNG with no upper bound. `--height` hard-crops the
+# render instead of scaling it, which is fine for a preview thumbnail (it
+# only needs to show the top of the email, not be a full readable
+# document). Observed in production: previews up to 1.7GB before this cap,
+# from an unbounded-height render, filling the mail-previews bucket.
+_MAX_RENDER_HEIGHT_PX = 4000
+
+# Belt-and-suspenders: even a capped-height render can still bloat past a
+# sane size (e.g. many large embedded images at full color). Drop the
+# render entirely rather than store it — MailPreviewView already treats a
+# missing preview as a 404 + lazy re-render trigger, so this degrades the
+# same way any other render failure does.
+_MAX_PNG_BYTES = 15 * 1024 * 1024
+
 _VISIBLE_HEADERS = ("From", "To", "Cc", "Subject", "Date", "Reply-To")
 
 _REMOTE_CSS_RE = re.compile(
@@ -264,6 +281,7 @@ class Eml2PngRenderer:
             "format": "png",
             "encoding": "utf-8",
             "width": str(_RENDER_WIDTH_PX),
+            "height": str(_MAX_RENDER_HEIGHT_PX),
             "quiet": "",
             "no-images": "",
             "disable-javascript": "",
@@ -271,10 +289,20 @@ class Eml2PngRenderer:
         }
 
         try:
-            return imgkit.from_string(html, output_path=False, options=options)
+            png_bytes = imgkit.from_string(html, output_path=False, options=options)
         except Exception as exc:
             logger.error("imgkit failed to render preview: %s", exc)
             return None
+
+        if png_bytes and len(png_bytes) > _MAX_PNG_BYTES:
+            logger.warning(
+                "imgkit preview render exceeded %d bytes (got %d) even after "
+                "the %dpx height cap — dropping instead of storing",
+                _MAX_PNG_BYTES, len(png_bytes), _MAX_RENDER_HEIGHT_PX,
+            )
+            return None
+
+        return png_bytes
 
 
 # ---------------------------------------------------------------------------

--- a/Suspicious/Suspicious/mail_feeder/utils/email_preview/retention.py
+++ b/Suspicious/Suspicious/mail_feeder/utils/email_preview/retention.py
@@ -1,0 +1,97 @@
+"""Purge objects from the `mail-previews` MinIO bucket.
+
+Operates directly on the bucket via `list_objects` (one listing call,
+using MinIO's own `.size`/`.last_modified` per object) rather than joining
+through `Mail` rows — there are no Mail-side timestamps to trust for this
+(a `Mail.date` header is attacker-controlled input parsed from the raw
+email), and it lets this run as a plain bucket sweep independent of the
+DB.
+
+Deliberately never touches `Mail.preview_bucket` / `preview_object_key`.
+Leaving those pointers in place after deleting the underlying object is
+safe and intentional: `MailPreviewView` already treats a MinIO
+get_object failure as a cache miss and calls `enqueue_preview_render`
+to lazily re-render on next view (see api/views/mail_preview.py). If we
+cleared the key instead, `sweep_missing_mail_previews` (which re-renders
+every row with a blank key, unconditionally, every 10 minutes) would
+re-generate every purged preview right back into existence.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Optional
+
+from django.utils import timezone
+
+from common.clients import get_s3_client
+from mail_feeder.utils.email_preview.eml2png_renderer import _DEFAULT_PREVIEW_BUCKET
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PurgeResult:
+    deleted_count: int = 0
+    deleted_bytes: int = 0
+    errors: list = field(default_factory=list)
+
+
+def purge_mail_previews(
+    *,
+    older_than_days: Optional[int] = None,
+    min_size_mb: Optional[float] = None,
+    dry_run: bool = False,
+    bucket: Optional[str] = None,
+) -> PurgeResult:
+    """Delete mail-preview objects matching age and/or size criteria.
+
+    An object is deleted if it satisfies EITHER given criterion (age past
+    `older_than_days`, or size past `min_size_mb`) — at least one of the
+    two must be provided. `dry_run=True` lists/sums matches without
+    deleting anything.
+    """
+    if older_than_days is None and min_size_mb is None:
+        raise ValueError("purge_mail_previews requires older_than_days and/or min_size_mb")
+
+    client = get_s3_client()
+    bucket = bucket or _DEFAULT_PREVIEW_BUCKET
+
+    if not client.bucket_exists(bucket):
+        logger.info("purge_mail_previews: bucket %s does not exist, nothing to do", bucket)
+        return PurgeResult()
+
+    cutoff = timezone.now() - timedelta(days=older_than_days) if older_than_days else None
+    min_size_bytes = int(min_size_mb * 1024 * 1024) if min_size_mb else None
+
+    result = PurgeResult()
+    for obj in client.list_objects(bucket, recursive=True):
+        size = obj.size or 0
+        last_modified = obj.last_modified
+
+        matches_age = cutoff is not None and last_modified is not None and last_modified < cutoff
+        matches_size = min_size_bytes is not None and size >= min_size_bytes
+        if not (matches_age or matches_size):
+            continue
+
+        if not dry_run:
+            try:
+                client.remove_object(bucket, obj.object_name)
+            except Exception:
+                logger.warning(
+                    "purge_mail_previews: failed to delete %s/%s",
+                    bucket, obj.object_name, exc_info=True,
+                )
+                result.errors.append(obj.object_name)
+                continue
+
+        result.deleted_count += 1
+        result.deleted_bytes += size
+
+    logger.info(
+        "purge_mail_previews: %s count=%d bytes=%d errors=%d bucket=%s",
+        "would delete" if dry_run else "deleted",
+        result.deleted_count, result.deleted_bytes, len(result.errors), bucket,
+    )
+    return result

--- a/Suspicious/Suspicious/suspicious/settings.py
+++ b/Suspicious/Suspicious/suspicious/settings.py
@@ -549,6 +549,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "tasp.tasks.delete_old_reports",
         "schedule": crontab(day_of_month=1, hour=0, minute=0),
     },
+    "purge-old-mail-previews": {
+        "task": "tasp.tasks.purge_old_mail_previews",
+        "schedule": crontab(hour=3, minute=0),
+    },
     "materialise-dashboard-snapshots": {
         "task": "tasp.tasks.materialise_dashboard_snapshots",
         "schedule": crontab(hour=2, minute=0),

--- a/Suspicious/Suspicious/tasp/tasks.py
+++ b/Suspicious/Suspicious/tasp/tasks.py
@@ -88,6 +88,22 @@ def delete_old_reports(self):
 
 
 @shared_task(bind=True, **_RETRY)
+def purge_old_mail_previews(self, older_than_days: int = 90):
+    """Age-only bucket sweep; see mail_feeder.utils.email_preview.retention
+    for why this never touches Mail.preview_object_key. Oversized-but-recent
+    outliers (the actual disk-usage incident) are a manual
+    `purge_mail_previews --min-size-mb` call, not part of the automated
+    sweep — an automatic size cutoff could delete a legitimately long
+    email's preview the same day it was rendered.
+    """
+    from mail_feeder.utils.email_preview.retention import purge_mail_previews
+    try:
+        purge_mail_previews(older_than_days=older_than_days)
+    except Exception as exc:
+        raise self.retry(exc=exc, countdown=60 * 2 ** self.request.retries)
+
+
+@shared_task(bind=True, **_RETRY)
 def materialise_dashboard_snapshots(self):
     from tasp.cron.dashboard_snapshot import materialise_dashboard_snapshots as _run
     try:


### PR DESCRIPTION
## Summary
- Production disk incident: `mail-previews` MinIO bucket at 58GB / 24827 objects, individual PNGs up to 1.7GB, zero cleanup ever run.
- Root cause: `wkhtmltoimage` renders the full page height unbounded — a pathologically tall email body (long quote chains, hostile HTML) produces an arbitrarily large PNG. Capped render height at 4000px and drop (never store) any render still over 15MB after cropping.
- Added a bucket sweep (`purge_mail_previews`) that deletes objects by age and/or size. It deliberately never touches `Mail.preview_object_key` — `MailPreviewView` already treats a missing MinIO object as a cache miss and lazily re-renders on next view, so leaving the DB pointer alone avoids `sweep_missing_mail_previews` (which re-renders every row with a blank key every 10 minutes) regenerating every purged preview right back.
- Wired as a daily Celery beat task (age-only, 90 days, conservative) and exposed as `manage.py purge_mail_previews --older-than-days N --min-size-mb N --dry-run` for an immediate manual pass targeting the existing oversized outliers regardless of age.

## Test plan
- [x] `mail_feeder.tests.test_retention` + `mail_feeder.tests.test_eml2png_render_limits` — 9/9 pass
- [x] Full `mail_feeder` + `tasp` app suites — 125/125 pass, no regressions
- [x] Full backend suite — 569/569 pass
- [ ] Deploy, then run `manage.py purge_mail_previews --min-size-mb 15 --dry-run` in prod to confirm the outlier count/size before doing a live run

🤖 Generated with [Claude Code](https://claude.com/claude-code)