### PR TITLE
feat(profile): avatar photo upload

### DIFF
--- a/Suspicious/Suspicious/api/serializers/profile.py
+++ b/Suspicious/Suspicious/api/serializers/profile.py
@@ -1,6 +1,7 @@
 import re
 from rest_framework import serializers
 from profiles.models import UserProfile, CISOProfile, Theme, DEFAULT_SEMANTIC_COLORS
+from profiles.profiles_utils.avatar_storage import presigned_avatar_url
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +141,12 @@ class AvatarField(serializers.JSONField):
         style = data.get("style")
         seed = data.get("seed")
 
+        if style == "upload":
+            raise serializers.ValidationError(
+                "avatar.style 'upload' can only be set via "
+                "POST /profile/avatar/upload/."
+            )
+
         if style not in ALLOWED_AVATAR_STYLES:
             raise serializers.ValidationError(
                 f"avatar.style must be one of {sorted(ALLOWED_AVATAR_STYLES)}. Got: {style!r}"
@@ -194,6 +201,11 @@ class UserProfileSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         rep = super().to_representation(instance)
         rep["semantic_colors"] = instance.get_semantic_colors()
+        avatar = rep.get("avatar") or {}
+        if avatar.get("style") == "upload" and avatar.get("seed"):
+            url = presigned_avatar_url(avatar["seed"])
+            if url:
+                rep["avatar"] = {**avatar, "url": url}
         return rep
 
 
@@ -232,6 +244,11 @@ class CISOProfileSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         rep = super().to_representation(instance)
         rep["semantic_colors"] = instance.get_semantic_colors()
+        avatar = rep.get("avatar") or {}
+        if avatar.get("style") == "upload" and avatar.get("seed"):
+            url = presigned_avatar_url(avatar["seed"])
+            if url:
+                rep["avatar"] = {**avatar, "url": url}
         return rep
 
 

--- a/Suspicious/Suspicious/api/serializers/profile.py
+++ b/Suspicious/Suspicious/api/serializers/profile.py
@@ -169,6 +169,7 @@ class AvatarField(serializers.JSONField):
 
 class UserProfileSerializer(serializers.ModelSerializer):
     semantic_colors = SemanticColorsField(required=False)
+    avatar = AvatarField(required=False)
 
     class Meta:
         model = UserProfile
@@ -211,6 +212,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
 
 class CISOProfileSerializer(serializers.ModelSerializer):
     semantic_colors = SemanticColorsField(required=False)
+    avatar = AvatarField(required=False)
 
     class Meta:
         model = CISOProfile

--- a/Suspicious/Suspicious/api/tests/test_profile_avatar.py
+++ b/Suspicious/Suspicious/api/tests/test_profile_avatar.py
@@ -186,3 +186,113 @@ class AvatarPresignedUrlExpansionTests(APITestCase):
             resp = self.client.get("/api/profile/")
         self.assertEqual(resp.status_code, 200)
         self.assertNotIn("url", resp.data["avatar"])
+
+
+import io
+import os
+from PIL import Image
+
+
+def _jpeg_upload(width=300, height=300, name="photo.jpg", content_type="image/jpeg"):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+    buf = io.BytesIO()
+    # ponytail: random noise (not a solid fill) so JPEG compression can't
+    # shrink a "big" image back under AVATAR_MAX_BYTES — a solid-color
+    # 3000x3000 JPEG compresses to ~140KB, which would silently defeat
+    # test_oversized_upload_rejected_without_storage_call.
+    raw = os.urandom(width * height * 3)
+    Image.frombytes("RGB", (width, height), raw).save(buf, format="JPEG")
+    return SimpleUploadedFile(name, buf.getvalue(), content_type=content_type)
+
+
+class AvatarUploadEndpointTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="dave", password="pw12345!")
+        self.client.force_authenticate(user=self.user)
+        self.url = "/api/profile/avatar/upload/"
+
+    def test_upload_sets_avatar_style_and_seed(self):
+        fake_client = mock.MagicMock()
+        fake_client.bucket_exists.return_value = True
+        fake_client.presigned_get_object.return_value = "https://rustfs/signed"
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ):
+            resp = self.client.post(
+                self.url, {"avatar": _jpeg_upload()}, format="multipart"
+            )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertEqual(resp.data["avatar"]["style"], "upload")
+        self.assertTrue(resp.data["avatar"]["seed"].startswith(f"avatars/{self.user.id}/"))
+        self.assertEqual(resp.data["avatar"]["url"], "https://rustfs/signed")
+        fake_client.put_object.assert_called_once()
+
+    def test_oversized_upload_rejected_without_storage_call(self):
+        fake_client = mock.MagicMock()
+        big = _jpeg_upload(width=3000, height=3000)
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ):
+            resp = self.client.post(self.url, {"avatar": big}, format="multipart")
+        if resp.status_code == 200:
+            self.fail("expected rejection for an oversized upload")
+        self.assertEqual(resp.status_code, 400)
+        fake_client.put_object.assert_not_called()
+
+    def test_corrupt_file_rejected(self):
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        bad = SimpleUploadedFile("photo.jpg", b"not-an-image", content_type="image/jpeg")
+        fake_client = mock.MagicMock()
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ):
+            resp = self.client.post(self.url, {"avatar": bad}, format="multipart")
+        self.assertEqual(resp.status_code, 400)
+        fake_client.put_object.assert_not_called()
+
+    def test_no_file_provided(self):
+        resp = self.client.post(self.url, {}, format="multipart")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_reupload_deletes_previous_object(self):
+        from profiles.models import UserProfile
+        profile, _ = UserProfile.objects.get_or_create(user=self.user)
+        profile.avatar = {"style": "upload", "seed": "avatars/1/old.jpg"}
+        profile.save(update_fields=["avatar"])
+
+        fake_client = mock.MagicMock()
+        fake_client.bucket_exists.return_value = True
+        fake_client.presigned_get_object.return_value = "https://rustfs/signed"
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ):
+            resp = self.client.post(
+                self.url, {"avatar": _jpeg_upload()}, format="multipart"
+            )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        fake_client.remove_object.assert_called_once_with(
+            "suspicious-avatars", "avatars/1/old.jpg"
+        )
+
+    def test_upload_works_for_ciso_profile(self):
+        from profiles.models import CISOProfile
+        CISOProfile.objects.get_or_create(
+            user=self.user,
+            defaults={"function": "f", "gbu": "g", "country": "c", "region": "r"},
+        )
+        fake_client = mock.MagicMock()
+        fake_client.bucket_exists.return_value = True
+        fake_client.presigned_get_object.return_value = "https://rustfs/signed"
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ):
+            resp = self.client.post(
+                self.url, {"avatar": _jpeg_upload()}, format="multipart"
+            )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertEqual(resp.data["avatar"]["style"], "upload")

--- a/Suspicious/Suspicious/api/tests/test_profile_avatar.py
+++ b/Suspicious/Suspicious/api/tests/test_profile_avatar.py
@@ -4,6 +4,8 @@ from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token  # noqa: F401 (import style parity)
 
+from profiles.profiles_utils.avatar_storage import AVATAR_MAX_BYTES
+
 User = get_user_model()
 
 
@@ -240,6 +242,35 @@ class AvatarUploadEndpointTests(APITestCase):
             self.fail("expected rejection for an oversized upload")
         self.assertEqual(resp.status_code, 400)
         fake_client.put_object.assert_not_called()
+
+    def test_oversized_upload_rejected_before_read(self):
+        """The view must reject on declared .size alone, before ever calling
+        process_avatar_image or upload.read(). Uses a mock upload (tiny
+        actual body, oversized declared .size) so the assertion holds
+        regardless of what a real multipart parser would report — going
+        through the test client would re-derive .size from actual bytes
+        transmitted, defeating the point of this test, so the view is
+        invoked directly instead."""
+        from api.views.profile import AvatarUploadView
+
+        fake_upload = mock.MagicMock()
+        fake_upload.content_type = "image/jpeg"
+        fake_upload.size = AVATAR_MAX_BYTES + 1
+        fake_upload.read = mock.MagicMock(
+            side_effect=AssertionError("upload.read() must not be called before the size gate")
+        )
+
+        request = mock.MagicMock()
+        request.FILES = {"avatar": fake_upload}
+        request.user = self.user
+
+        with mock.patch("api.views.profile.process_avatar_image") as mock_process:
+            resp = AvatarUploadView().post(request)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn(str(AVATAR_MAX_BYTES), resp.data["detail"])
+        mock_process.assert_not_called()
+        fake_upload.read.assert_not_called()
 
     def test_corrupt_file_rejected(self):
         from django.core.files.uploadedfile import SimpleUploadedFile

--- a/Suspicious/Suspicious/api/tests/test_profile_avatar.py
+++ b/Suspicious/Suspicious/api/tests/test_profile_avatar.py
@@ -125,6 +125,34 @@ class AvatarUploadStyleRejectedViaAppearanceTests(APITestCase):
         self.assertEqual(resp.status_code, 400)
 
 
+class AvatarValidationViaProfileEndpointTests(APITestCase):
+    """PATCH /api/profile/ must apply the same AvatarField validation as
+    PATCH /profile/appearance/ — regression test for the bypass where
+    UserProfileSerializer/CISOProfileSerializer listed "avatar" in
+    Meta.fields without an explicit AvatarField, so DRF auto-generated an
+    unvalidated bare JSONField."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="dave", password="pw12345!")
+        self.client.force_authenticate(user=self.user)
+        self.url = "/api/profile/"
+
+    def test_upload_style_rejected_via_profile_patch(self):
+        resp = self.client.patch(
+            self.url, {"avatar": {"style": "upload", "seed": "x"}}, format="json"
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_valid_avatar_accepted_via_profile_patch(self):
+        resp = self.client.patch(
+            self.url,
+            {"avatar": {"style": "avataaars", "seed": "abc123"}},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertEqual(resp.data["avatar"], {"style": "avataaars", "seed": "abc123"})
+
+
 class AvatarPresignedUrlExpansionTests(APITestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="carol", password="pw12345!")

--- a/Suspicious/Suspicious/api/tests/test_profile_avatar.py
+++ b/Suspicious/Suspicious/api/tests/test_profile_avatar.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 from rest_framework.authtoken.models import Token  # noqa: F401 (import style parity)
@@ -107,3 +109,52 @@ class AvatarAppearanceTests(APITestCase):
         )
         self.assertEqual(resp.status_code, 200, resp.content)
         self.assertEqual(resp.data["avatar"], {"style": "avataaars", "seed": "abc123"})
+
+
+class AvatarUploadStyleRejectedViaAppearanceTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="bob", password="pw12345!")
+        self.client.force_authenticate(user=self.user)
+
+    def test_upload_style_rejected_via_appearance_patch(self):
+        resp = self.client.patch(
+            "/api/profile/appearance/",
+            {"avatar": {"style": "upload", "seed": "avatars/1/x.jpg"}},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+
+class AvatarPresignedUrlExpansionTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="carol", password="pw12345!")
+        self.client.force_authenticate(user=self.user)
+
+    def test_get_profile_expands_upload_avatar_to_presigned_url(self):
+        from profiles.models import UserProfile
+        profile, _ = UserProfile.objects.get_or_create(user=self.user)
+        profile.avatar = {"style": "upload", "seed": "avatars/1/abc.jpg"}
+        profile.save(update_fields=["avatar"])
+
+        with mock.patch(
+            "api.serializers.profile.presigned_avatar_url",
+            return_value="https://rustfs/signed-url",
+        ):
+            resp = self.client.get("/api/profile/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["avatar"]["style"], "upload")
+        self.assertEqual(resp.data["avatar"]["seed"], "avatars/1/abc.jpg")
+        self.assertEqual(resp.data["avatar"]["url"], "https://rustfs/signed-url")
+
+    def test_get_profile_omits_url_when_presign_fails(self):
+        from profiles.models import UserProfile
+        profile, _ = UserProfile.objects.get_or_create(user=self.user)
+        profile.avatar = {"style": "upload", "seed": "avatars/1/abc.jpg"}
+        profile.save(update_fields=["avatar"])
+
+        with mock.patch(
+            "api.serializers.profile.presigned_avatar_url", return_value=None
+        ):
+            resp = self.client.get("/api/profile/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("url", resp.data["avatar"])

--- a/Suspicious/Suspicious/api/urls.py
+++ b/Suspicious/Suspicious/api/urls.py
@@ -33,6 +33,7 @@ from api.views.investigations import (
 from api.views.profile import (
     ProfileView,
     AppearanceView,
+    AvatarUploadView,
     PreferencesView,
     SemanticColorsView,
     ResetSemanticColorsView,
@@ -100,11 +101,12 @@ urlpatterns = [
     path("campaigns/pca/", CampaignPcaView.as_view(), name="campaign-pca"),
     path("campaigns/mail-volume/", CampaignMailVolumeView.as_view(), name="campaign-mail-volume"),
 
-    path("profile/",             ProfileView.as_view(),             name="profile"),
-    path("profile/appearance/",  AppearanceView.as_view(),          name="profile-appearance"),
-    path("profile/preferences/", PreferencesView.as_view(),         name="profile-preferences"),
-    path("profile/colors/",      SemanticColorsView.as_view(),      name="profile-colors"),
-    path("profile/colors/reset/",ResetSemanticColorsView.as_view(), name="profile-colors-reset"),
+    path("profile/",              ProfileView.as_view(),             name="profile"),
+    path("profile/appearance/",   AppearanceView.as_view(),          name="profile-appearance"),
+    path("profile/avatar/upload/",AvatarUploadView.as_view(),        name="profile-avatar-upload"),
+    path("profile/preferences/",  PreferencesView.as_view(),         name="profile-preferences"),
+    path("profile/colors/",       SemanticColorsView.as_view(),      name="profile-colors"),
+    path("profile/colors/reset/", ResetSemanticColorsView.as_view(), name="profile-colors-reset"),
 
     path("submissions/", SubmissionListView.as_view(), name="submissions-list"),
     path("submissions/<int:submission_id>/", SubmissionDetailsView.as_view(), name="submission-details"),

--- a/Suspicious/Suspicious/api/views/profile.py
+++ b/Suspicious/Suspicious/api/views/profile.py
@@ -1,8 +1,15 @@
+from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from profiles.models import UserProfile, CISOProfile
+from profiles.profiles_utils.avatar_storage import (
+    InvalidAvatarImage,
+    delete_avatar,
+    process_avatar_image,
+    store_avatar,
+)
 from api.serializers.profile import (
     UserProfileSerializer,
     CISOProfileSerializer,
@@ -122,3 +129,44 @@ class ResetSemanticColorsView(APIView):
                 "profile": ProfileSerializerClass(profile).data,
             }
         )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/profile/avatar/upload/
+# ---------------------------------------------------------------------------
+
+class AvatarUploadView(APIView):
+    permission_classes = [IsAuthenticated]
+    parser_classes = [MultiPartParser]
+
+    def post(self, request):
+        upload = request.FILES.get("avatar")
+        if upload is None:
+            return Response({"detail": "No file provided."}, status=400)
+
+        try:
+            processed = process_avatar_image(
+                content_type=upload.content_type,
+                size=upload.size,
+                raw=upload.read(),
+            )
+        except InvalidAvatarImage as exc:
+            return Response({"detail": str(exc)}, status=400)
+
+        profile, SerializerClass = _get_profile(request.user)
+        old_avatar = profile.avatar or {}
+
+        try:
+            key = store_avatar(request.user.id, processed)
+        except Exception:
+            return Response(
+                {"detail": "Avatar storage is unavailable."}, status=502
+            )
+
+        if old_avatar.get("style") == "upload" and old_avatar.get("seed"):
+            delete_avatar(old_avatar["seed"])
+
+        profile.avatar = {"style": "upload", "seed": key}
+        profile.save(update_fields=["avatar", "last_update"])
+
+        return Response(SerializerClass(profile).data)

--- a/Suspicious/Suspicious/api/views/profile.py
+++ b/Suspicious/Suspicious/api/views/profile.py
@@ -163,8 +163,12 @@ class AvatarUploadView(APIView):
                 size=upload.size,
                 raw=upload.read(),
             )
-        except InvalidAvatarImage as exc:
-            return Response({"detail": str(exc)}, status=400)
+        except InvalidAvatarImage:
+            logger.exception(
+                "avatar process_avatar_image failed validation for user_id=%s",
+                request.user.id,
+            )
+            return Response({"detail": "Invalid avatar image."}, status=400)
 
         profile, SerializerClass = _get_profile(request.user)
         old_avatar = profile.avatar or {}

--- a/Suspicious/Suspicious/api/views/profile.py
+++ b/Suspicious/Suspicious/api/views/profile.py
@@ -1,3 +1,5 @@
+import logging
+
 from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -5,6 +7,7 @@ from rest_framework.views import APIView
 
 from profiles.models import UserProfile, CISOProfile
 from profiles.profiles_utils.avatar_storage import (
+    AVATAR_MAX_BYTES,
     InvalidAvatarImage,
     delete_avatar,
     process_avatar_image,
@@ -17,6 +20,8 @@ from api.serializers.profile import (
     PreferencesSerializer,
     SemanticColorsSerializer,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +149,14 @@ class AvatarUploadView(APIView):
         if upload is None:
             return Response({"detail": "No file provided."}, status=400)
 
+        if upload.size > AVATAR_MAX_BYTES:
+            return Response(
+                {
+                    "detail": f"File too large: {upload.size} bytes (max {AVATAR_MAX_BYTES})"
+                },
+                status=400,
+            )
+
         try:
             processed = process_avatar_image(
                 content_type=upload.content_type,
@@ -159,6 +172,9 @@ class AvatarUploadView(APIView):
         try:
             key = store_avatar(request.user.id, processed)
         except Exception:
+            logger.exception(
+                "avatar store_avatar failed for user_id=%s", request.user.id
+            )
             return Response(
                 {"detail": "Avatar storage is unavailable."}, status=502
             )

--- a/Suspicious/Suspicious/profiles/profiles_utils/avatar_storage.py
+++ b/Suspicious/Suspicious/profiles/profiles_utils/avatar_storage.py
@@ -91,8 +91,8 @@ def delete_avatar(key: str) -> None:
     try:
         client = get_s3_client()
         client.remove_object(_avatar_bucket_name(), key)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning(f"Failed to delete avatar object {key!r}: {exc}")
 
 
 def presigned_avatar_url(key: str) -> str | None:
@@ -102,5 +102,6 @@ def presigned_avatar_url(key: str) -> str | None:
         return client.presigned_get_object(
             _avatar_bucket_name(), key, expires=AVATAR_URL_EXPIRES
         )
-    except Exception:
+    except Exception as exc:
+        logger.warning(f"Failed to presign avatar URL for {key!r}: {exc}")
         return None

--- a/Suspicious/Suspicious/profiles/profiles_utils/avatar_storage.py
+++ b/Suspicious/Suspicious/profiles/profiles_utils/avatar_storage.py
@@ -1,0 +1,102 @@
+"""MinIO-backed storage for uploaded avatar photos.
+
+Deliberately not sharing case_handler's MinioManager (mail/case-artifact
+specific) — profiles has no business importing that app's internals, so
+this talks to the shared common.clients.get_s3_client() MinIO client
+directly, same as tasp.cron.fetch_emails and mail_feeder do.
+"""
+from __future__ import annotations
+
+import io
+import uuid
+from datetime import timedelta
+
+from PIL import Image, UnidentifiedImageError
+
+from common.clients import get_s3_client
+from settings.config import get_section
+
+DEFAULT_AVATAR_BUCKET = "suspicious-avatars"
+AVATAR_MAX_BYTES = 2 * 1024 * 1024
+AVATAR_ALLOWED_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
+AVATAR_DIMENSION = 512
+AVATAR_URL_EXPIRES = timedelta(hours=1)
+
+
+class InvalidAvatarImage(Exception):
+    """Raised when an uploaded file fails format/size/decode validation."""
+
+
+def _avatar_bucket_name() -> str:
+    try:
+        return (get_section("storage.s3") or {}).get("avatars_bucket") or DEFAULT_AVATAR_BUCKET
+    except Exception:
+        return DEFAULT_AVATAR_BUCKET
+
+
+def _ensure_bucket(client, bucket_name: str) -> None:
+    if not client.bucket_exists(bucket_name):
+        client.make_bucket(bucket_name)
+
+
+def process_avatar_image(content_type: str, size: int, raw: bytes) -> bytes:
+    """Validate + center-crop + resize + re-encode an uploaded avatar.
+
+    Raises InvalidAvatarImage on any validation failure. Returns JPEG
+    bytes ready to store — the re-encode is also what strips EXIF, since
+    Pillow does not carry source metadata into a freshly-encoded output.
+    """
+    if content_type not in AVATAR_ALLOWED_CONTENT_TYPES:
+        raise InvalidAvatarImage(f"Unsupported content type: {content_type!r}")
+    if size > AVATAR_MAX_BYTES:
+        raise InvalidAvatarImage(f"File too large: {size} bytes (max {AVATAR_MAX_BYTES})")
+
+    try:
+        Image.open(io.BytesIO(raw)).verify()
+        image = Image.open(io.BytesIO(raw)).convert("RGB")
+    except (UnidentifiedImageError, OSError) as exc:
+        raise InvalidAvatarImage("File is not a valid image") from exc
+
+    width, height = image.size
+    side = min(width, height)
+    left = (width - side) // 2
+    top = (height - side) // 2
+    image = image.crop((left, top, left + side, top + side))
+    image = image.resize((AVATAR_DIMENSION, AVATAR_DIMENSION), Image.LANCZOS)
+
+    out = io.BytesIO()
+    image.save(out, format="JPEG", quality=85)
+    return out.getvalue()
+
+
+def store_avatar(user_id: int, image_bytes: bytes) -> str:
+    """Upload processed JPEG bytes, return the new object key."""
+    client = get_s3_client()
+    bucket = _avatar_bucket_name()
+    _ensure_bucket(client, bucket)
+    key = f"avatars/{user_id}/{uuid.uuid4().hex}.jpg"
+    client.put_object(
+        bucket, key, io.BytesIO(image_bytes),
+        length=len(image_bytes), content_type="image/jpeg",
+    )
+    return key
+
+
+def delete_avatar(key: str) -> None:
+    """Best-effort delete of a previous avatar object. Never raises."""
+    try:
+        client = get_s3_client()
+        client.remove_object(_avatar_bucket_name(), key)
+    except Exception:
+        pass
+
+
+def presigned_avatar_url(key: str) -> str | None:
+    """Presigned GET URL for a stored avatar, or None on any failure."""
+    try:
+        client = get_s3_client()
+        return client.presigned_get_object(
+            _avatar_bucket_name(), key, expires=AVATAR_URL_EXPIRES
+        )
+    except Exception:
+        return None

--- a/Suspicious/Suspicious/profiles/profiles_utils/avatar_storage.py
+++ b/Suspicious/Suspicious/profiles/profiles_utils/avatar_storage.py
@@ -8,6 +8,7 @@ directly, same as tasp.cron.fetch_emails and mail_feeder do.
 from __future__ import annotations
 
 import io
+import logging
 import uuid
 from datetime import timedelta
 
@@ -15,6 +16,8 @@ from PIL import Image, UnidentifiedImageError
 
 from common.clients import get_s3_client
 from settings.config import get_section
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_AVATAR_BUCKET = "suspicious-avatars"
 AVATAR_MAX_BYTES = 2 * 1024 * 1024
@@ -30,7 +33,8 @@ class InvalidAvatarImage(Exception):
 def _avatar_bucket_name() -> str:
     try:
         return (get_section("storage.s3") or {}).get("avatars_bucket") or DEFAULT_AVATAR_BUCKET
-    except Exception:
+    except Exception as exc:
+        logger.warning(f"Failed to read avatars_bucket from config: {exc}. Using default: {DEFAULT_AVATAR_BUCKET}")
         return DEFAULT_AVATAR_BUCKET
 
 
@@ -54,7 +58,7 @@ def process_avatar_image(content_type: str, size: int, raw: bytes) -> bytes:
     try:
         Image.open(io.BytesIO(raw)).verify()
         image = Image.open(io.BytesIO(raw)).convert("RGB")
-    except (UnidentifiedImageError, OSError) as exc:
+    except (UnidentifiedImageError, OSError, Image.DecompressionBombError) as exc:
         raise InvalidAvatarImage("File is not a valid image") from exc
 
     width, height = image.size

--- a/Suspicious/Suspicious/profiles/profiles_utils/test_avatar_storage.py
+++ b/Suspicious/Suspicious/profiles/profiles_utils/test_avatar_storage.py
@@ -1,0 +1,132 @@
+import io
+from unittest import mock
+
+from django.test import SimpleTestCase
+from PIL import Image
+
+from profiles.profiles_utils.avatar_storage import (
+    AVATAR_DIMENSION,
+    InvalidAvatarImage,
+    delete_avatar,
+    presigned_avatar_url,
+    process_avatar_image,
+    store_avatar,
+)
+
+
+def _jpeg_bytes(width=800, height=400, color=(255, 0, 0)):
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+class ProcessAvatarImageTest(SimpleTestCase):
+    def test_rejects_unsupported_content_type(self):
+        with self.assertRaises(InvalidAvatarImage):
+            process_avatar_image("image/gif", 100, b"whatever")
+
+    def test_rejects_oversized_file(self):
+        raw = _jpeg_bytes()
+        with self.assertRaises(InvalidAvatarImage):
+            process_avatar_image("image/jpeg", 3 * 1024 * 1024, raw)
+
+    def test_rejects_corrupt_file_with_valid_content_type(self):
+        with self.assertRaises(InvalidAvatarImage):
+            process_avatar_image("image/jpeg", 10, b"not-an-image")
+
+    def test_valid_jpeg_is_cropped_to_square_and_resized(self):
+        raw = _jpeg_bytes(width=800, height=400)
+        out = process_avatar_image("image/jpeg", len(raw), raw)
+        img = Image.open(io.BytesIO(out))
+        self.assertEqual(img.size, (AVATAR_DIMENSION, AVATAR_DIMENSION))
+        self.assertEqual(img.format, "JPEG")
+
+    def test_valid_png_is_accepted_and_reencoded_as_jpeg(self):
+        buf = io.BytesIO()
+        Image.new("RGB", (300, 300), (0, 255, 0)).save(buf, format="PNG")
+        raw = buf.getvalue()
+        out = process_avatar_image("image/png", len(raw), raw)
+        img = Image.open(io.BytesIO(out))
+        self.assertEqual(img.format, "JPEG")
+
+    def test_exif_is_not_preserved(self):
+        buf = io.BytesIO()
+        img = Image.new("RGB", (300, 300), (0, 0, 255))
+        exif = img.getexif()
+        exif[0x9286] = "some comment"  # UserComment tag
+        img.save(buf, format="JPEG", exif=exif)
+        raw = buf.getvalue()
+        out = process_avatar_image("image/jpeg", len(raw), raw)
+        out_img = Image.open(io.BytesIO(out))
+        self.assertEqual(dict(out_img.getexif()), {})
+
+
+class StoreAvatarTest(SimpleTestCase):
+    def test_store_avatar_uploads_and_returns_key(self):
+        fake_client = mock.MagicMock()
+        fake_client.bucket_exists.return_value = True
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ):
+            key = store_avatar(42, b"jpegbytes")
+        self.assertTrue(key.startswith("avatars/42/"))
+        self.assertTrue(key.endswith(".jpg"))
+        fake_client.put_object.assert_called_once()
+        call = fake_client.put_object.call_args
+        self.assertEqual(call.args[0], "suspicious-avatars")
+        self.assertEqual(call.args[1], key)
+
+    def test_store_avatar_creates_bucket_if_missing(self):
+        fake_client = mock.MagicMock()
+        fake_client.bucket_exists.return_value = False
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ):
+            store_avatar(1, b"bytes")
+        fake_client.make_bucket.assert_called_once_with("suspicious-avatars")
+
+
+class DeleteAvatarTest(SimpleTestCase):
+    def test_delete_avatar_calls_remove_object(self):
+        fake_client = mock.MagicMock()
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ):
+            delete_avatar("avatars/1/abc.jpg")
+        fake_client.remove_object.assert_called_once_with(
+            "suspicious-avatars", "avatars/1/abc.jpg"
+        )
+
+    def test_delete_avatar_never_raises(self):
+        fake_client = mock.MagicMock()
+        fake_client.remove_object.side_effect = Exception("network down")
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ):
+            delete_avatar("avatars/1/abc.jpg")  # must not raise
+
+
+class PresignedAvatarUrlTest(SimpleTestCase):
+    def test_returns_url_from_client(self):
+        fake_client = mock.MagicMock()
+        fake_client.presigned_get_object.return_value = "https://rustfs/signed"
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ):
+            url = presigned_avatar_url("avatars/1/abc.jpg")
+        self.assertEqual(url, "https://rustfs/signed")
+
+    def test_returns_none_on_failure(self):
+        fake_client = mock.MagicMock()
+        fake_client.presigned_get_object.side_effect = Exception("boom")
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ):
+            url = presigned_avatar_url("avatars/1/abc.jpg")
+        self.assertIsNone(url)

--- a/Suspicious/Suspicious/profiles/profiles_utils/test_avatar_storage.py
+++ b/Suspicious/Suspicious/profiles/profiles_utils/test_avatar_storage.py
@@ -60,6 +60,17 @@ class ProcessAvatarImageTest(SimpleTestCase):
         out_img = Image.open(io.BytesIO(out))
         self.assertEqual(dict(out_img.getexif()), {})
 
+    def test_decompression_bomb_raises_invalid_avatar_image(self):
+        # A real bomb file has huge declared dimensions but a tiny byte
+        # size (a solid color compresses to almost nothing) — Pillow's
+        # guard fires off the declared header size, not actual decoded
+        # memory, so we don't need to allocate a giant image here: lower
+        # MAX_IMAGE_PIXELS instead so an ordinary small image trips it.
+        raw = _jpeg_bytes(width=300, height=300)
+        with mock.patch.object(Image, "MAX_IMAGE_PIXELS", 100):
+            with self.assertRaises(InvalidAvatarImage):
+                process_avatar_image("image/jpeg", len(raw), raw)
+
 
 class StoreAvatarTest(SimpleTestCase):
     def test_store_avatar_uploads_and_returns_key(self):
@@ -86,6 +97,21 @@ class StoreAvatarTest(SimpleTestCase):
         ):
             store_avatar(1, b"bytes")
         fake_client.make_bucket.assert_called_once_with("suspicious-avatars")
+
+    def test_store_avatar_uses_configured_bucket_name(self):
+        fake_client = mock.MagicMock()
+        fake_client.bucket_exists.return_value = True
+        with mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            return_value=fake_client,
+        ), mock.patch(
+            "profiles.profiles_utils.avatar_storage.get_section",
+            return_value={"avatars_bucket": "custom-bucket"},
+        ):
+            store_avatar(42, b"jpegbytes")
+        # Verify that custom-bucket was used, not the default
+        call = fake_client.put_object.call_args
+        self.assertEqual(call.args[0], "custom-bucket")
 
 
 class DeleteAvatarTest(SimpleTestCase):

--- a/suspicious-ui/src/features/profile/AvatarPanel.tsx
+++ b/suspicious-ui/src/features/profile/AvatarPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Box, Button, Divider, Stack, Typography } from "@mui/material";
 import { alpha, useTheme } from "@mui/material/styles";
-import { PersonOutlined, CasinoOutlined } from "@mui/icons-material";
+import { PersonOutlined, CasinoOutlined, AddAPhotoOutlined } from "@mui/icons-material";
 import { CaptionLabel, InnerCard } from "@/features/profile/components/cards";
 import { UserAvatar } from "@/features/profile/components/UserAvatar";
 import { ColorField } from "@/features/profile/components/ColorField";
@@ -15,12 +15,15 @@ import {
   type AvatarConfig,
 } from "@/features/profile/avatar";
 import { initials as initialsFn } from "@/features/profile/utils";
+import { uploadAvatar } from "@/features/profile/api";
 
 export function AvatarPanel({
   style, seed, setStyle, setSeed,
   options, setOptions,
   firstName, lastName,
   dirtyBar,
+  photoUrl,
+  onUploaded,
 }: {
   style: string; seed: string;
   setStyle: (s: string) => void; setSeed: (s: string) => void;
@@ -28,12 +31,53 @@ export function AvatarPanel({
   setOptions: (o: Record<string, string[]>) => void;
   firstName?: string; lastName?: string;
   dirtyBar: React.ReactNode;
+  photoUrl?: string;
+  onUploaded: (avatar: { style: "upload"; seed: string; url?: string }) => void;
 }) {
   const theme = useTheme();
   const inits = initialsFn(firstName, lastName);
   const isInitials = style === "initials";
   const effectiveSeed = isInitials ? inits : seed;
   const config: AvatarConfig = { style, seed: effectiveSeed, options };
+
+  const displayConfig: AvatarConfig =
+    style === "upload" ? { style, seed, url: photoUrl } : config;
+
+  const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+  const MAX_BYTES = 2 * 1024 * 1024;
+
+  const [uploadError, setUploadError] = React.useState<string | null>(null);
+  const [uploading, setUploading] = React.useState(false);
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    setUploadError(null);
+
+    if (!ACCEPTED_TYPES.includes(file.type)) {
+      setUploadError("Only JPG, PNG, or WebP images are supported.");
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      setUploadError(`File too large — max 2 MB, got ${(file.size / 1024 / 1024).toFixed(1)} MB.`);
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const updated = await uploadAvatar(file);
+      if (updated.avatar?.style === "upload" && updated.avatar.seed) {
+        onUploaded({ style: "upload", seed: updated.avatar.seed, url: updated.avatar.url });
+      }
+    } catch (err: unknown) {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setUploadError(detail ?? "Upload failed — please try again.");
+    } finally {
+      setUploading(false);
+    }
+  };
 
   const categories = getStyleCategories(style);
   const styleOptionCats = categories.filter((c) => c.kind === "enum");
@@ -90,7 +134,7 @@ export function AvatarPanel({
           }}
         >
           <InnerCard sx={{ p: 2.5, display: "flex", flexDirection: "column", alignItems: "center", gap: 1.25 }}>
-            <UserAvatar avatar={config} initials={inits} sx={{ width: 96, height: 96, fontSize: 34, fontWeight: 950 }} />
+            <UserAvatar avatar={displayConfig} initials={inits} sx={{ width: 96, height: 96, fontSize: 34, fontWeight: 950 }} />
             <Typography sx={{ fontWeight: 900, fontSize: 14, textAlign: "center" }}>
               {AVATAR_STYLES.find((s) => s.key === style)?.label ?? "Initials"}
             </Typography>
@@ -112,6 +156,32 @@ export function AvatarPanel({
           <Stack spacing={1}>
             <CaptionLabel>Style</CaptionLabel>
             <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(84px, 1fr))", gap: 1 }}>
+              <Box
+                component="label"
+                htmlFor="avatar-upload-input"
+                sx={{
+                  cursor: uploading ? "wait" : "pointer", borderRadius: 2.5, p: 1,
+                  display: "flex", flexDirection: "column", alignItems: "center", gap: 0.5,
+                  border: `1px solid ${style === "upload" ? theme.palette.primary.main : alpha(theme.palette.divider, 0.5)}`,
+                  background: style === "upload" ? alpha(theme.palette.primary.main, 0.08) : "transparent",
+                }}
+              >
+                <Box sx={{ width: 44, height: 44, display: "grid", placeItems: "center" }}>
+                  <AddAPhotoOutlined sx={{ fontSize: 22 }} />
+                </Box>
+                <Typography variant="caption" sx={{ fontWeight: style === "upload" ? 900 : 700, fontSize: 10.5 }}>
+                  Upload photo
+                </Typography>
+                <input
+                  id="avatar-upload-input"
+                  aria-label="Upload photo"
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  disabled={uploading}
+                  onChange={handleFileSelect}
+                  style={{ display: "none" }}
+                />
+              </Box>
               {AVATAR_STYLES.map((s) => {
                 const selected = s.key === style;
                 const preview = renderAvatarDataUri({
@@ -144,6 +214,11 @@ export function AvatarPanel({
                 );
               })}
             </Box>
+            {uploadError && (
+              <Typography variant="caption" color="error" role="alert">
+                {uploadError}
+              </Typography>
+            )}
           </Stack>
 
           {styleOptionCats.length > 0 && (

--- a/suspicious-ui/src/features/profile/__tests__/AvatarPanel.test.tsx
+++ b/suspicious-ui/src/features/profile/__tests__/AvatarPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AvatarPanel } from "@/features/profile/AvatarPanel";
@@ -9,6 +9,7 @@ function renderPanel(
 ) {
   const setOptions = vi.fn();
   const setSeed = vi.fn();
+  const onUploaded = vi.fn();
   render(
     <AvatarPanel
       style="avataaars"
@@ -20,10 +21,11 @@ function renderPanel(
       firstName="Al"
       lastName="Ice"
       dirtyBar={null}
+      onUploaded={onUploaded}
       {...overrides}
     />,
   );
-  return { setOptions, setSeed };
+  return { setOptions, setSeed, onUploaded };
 }
 
 describe("AvatarPanel style options (enum categories)", () => {
@@ -88,5 +90,60 @@ describe("AvatarPanel styles with no color fields", () => {
     renderPanel({ style: "notionists" });
     expect(screen.queryByText("Colors")).not.toBeInTheDocument();
     expect(screen.queryByText("Background")).not.toBeInTheDocument();
+  });
+});
+
+vi.mock("@/features/profile/api", () => ({
+  uploadAvatar: vi.fn(),
+}));
+
+import { uploadAvatar } from "@/features/profile/api";
+
+describe("AvatarPanel upload", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("uploads the selected file and calls onUploaded with the result", async () => {
+    vi.mocked(uploadAvatar).mockResolvedValue({
+      id: 1,
+      avatar: { style: "upload", seed: "avatars/1/x.jpg", url: "https://signed" },
+    } as never);
+
+    const onUploaded = vi.fn();
+    renderPanel({ onUploaded });
+
+    const file = new File(["bytes"], "photo.jpg", { type: "image/jpeg" });
+    const input = screen.getByLabelText(/upload photo/i) as HTMLInputElement;
+    await userEvent.upload(input, file);
+
+    await vi.waitFor(() => {
+      expect(uploadAvatar).toHaveBeenCalledWith(file);
+      expect(onUploaded).toHaveBeenCalledWith({
+        style: "upload", seed: "avatars/1/x.jpg", url: "https://signed",
+      });
+    });
+  });
+
+  it("shows an inline error when the upload is rejected", async () => {
+    vi.mocked(uploadAvatar).mockRejectedValue({
+      response: { data: { detail: "File too large: 3000000 bytes (max 2097152)" } },
+    });
+
+    renderPanel();
+
+    const file = new File(["bytes"], "photo.jpg", { type: "image/jpeg" });
+    const input = screen.getByLabelText(/upload photo/i) as HTMLInputElement;
+    await userEvent.upload(input, file);
+
+    expect(await screen.findByText(/file too large/i)).toBeInTheDocument();
+  });
+
+  it("rejects an oversized file client-side without calling the API", async () => {
+    renderPanel();
+    const big = new File([new Uint8Array(3 * 1024 * 1024)], "big.jpg", { type: "image/jpeg" });
+    const input = screen.getByLabelText(/upload photo/i) as HTMLInputElement;
+    await userEvent.upload(input, big);
+
+    expect(await screen.findByText(/2\s*mb/i)).toBeInTheDocument();
+    expect(uploadAvatar).not.toHaveBeenCalled();
   });
 });

--- a/suspicious-ui/src/features/profile/__tests__/UserAvatar.test.tsx
+++ b/suspicious-ui/src/features/profile/__tests__/UserAvatar.test.tsx
@@ -27,4 +27,22 @@ describe("UserAvatar", () => {
     expect(svg).toContain(">JD<");
     expect(svg).not.toContain("zz9k2x");
   });
+
+  it("renders the uploaded photo when style is upload and a url is present", () => {
+    render(
+      <UserAvatar
+        avatar={{ style: "upload", seed: "avatars/1/x.jpg", url: "https://rustfs/signed" }}
+        initials="EF"
+      />
+    );
+    const img = screen.getByRole("img");
+    expect(img.getAttribute("src")).toBe("https://rustfs/signed");
+  });
+
+  it("falls back to initials when style is upload but url is missing", () => {
+    render(
+      <UserAvatar avatar={{ style: "upload", seed: "avatars/1/x.jpg" }} initials="GH" />
+    );
+    expect(screen.getByText("GH")).toBeInTheDocument();
+  });
 });

--- a/suspicious-ui/src/features/profile/__tests__/api.test.ts
+++ b/suspicious-ui/src/features/profile/__tests__/api.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { api } from "@/api/client";
+import { uploadAvatar } from "@/features/profile/api";
+
+vi.mock("@/api/client", () => ({
+  api: { post: vi.fn() },
+}));
+
+describe("uploadAvatar", () => {
+  it("POSTs the file as multipart form data to the upload endpoint", async () => {
+    const fakeProfile = { id: 1, avatar: { style: "upload", seed: "avatars/1/x.jpg", url: "https://x" } };
+    vi.mocked(api.post).mockResolvedValue({ data: fakeProfile });
+
+    const file = new File(["bytes"], "photo.jpg", { type: "image/jpeg" });
+    const result = await uploadAvatar(file);
+
+    expect(result).toEqual(fakeProfile);
+    expect(api.post).toHaveBeenCalledTimes(1);
+    const [url, body] = vi.mocked(api.post).mock.calls[0];
+    expect(url).toBe("/profile/avatar/upload/");
+    expect(body).toBeInstanceOf(FormData);
+    expect((body as FormData).get("avatar")).toBe(file);
+  });
+});

--- a/suspicious-ui/src/features/profile/api.ts
+++ b/suspicious-ui/src/features/profile/api.ts
@@ -61,6 +61,18 @@ export async function getProfile(): Promise<UserProfile> {
 }
 
 // ---------------------------------------------------------------------------
+// POST /api/profile/avatar/upload/
+// ---------------------------------------------------------------------------
+
+export async function uploadAvatar(file: File): Promise<UserProfile> {
+  const form = new FormData();
+  form.append("avatar", file);
+  const { data } = await api.post<UserProfile>("/profile/avatar/upload/", form);
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/profile/appearance/
 // ---------------------------------------------------------------------------
 
 export async function updateAppearance(

--- a/suspicious-ui/src/features/profile/avatar.ts
+++ b/suspicious-ui/src/features/profile/avatar.ts
@@ -14,6 +14,8 @@ export type AvatarConfig = {
   style: string;
   seed: string;
   options?: Record<string, string[]>;
+  /** Presigned MinIO URL, present only when style === "upload". Server-populated; never sent by the client. */
+  url?: string;
 };
 
 export const AVATAR_STYLES = [

--- a/suspicious-ui/src/features/profile/components/UserAvatar.tsx
+++ b/suspicious-ui/src/features/profile/components/UserAvatar.tsx
@@ -12,9 +12,13 @@ export function UserAvatar({
   initials: string;
   sx?: SxProps<Theme>;
 } & Record<string, unknown>) {
+  if (avatar?.style === "upload" && avatar.url) {
+    return <Avatar src={avatar.url} alt={initials} sx={sx} {...rest} />;
+  }
+
   const effectiveSeed = avatar?.style === "initials" ? initials : avatar?.seed;
   const src =
-    avatar?.style && effectiveSeed
+    avatar?.style && avatar.style !== "upload" && effectiveSeed
       ? renderAvatarDataUri({ ...avatar, seed: effectiveSeed })
       : "";
 

--- a/suspicious-ui/src/pages/ProfilePage.tsx
+++ b/suspicious-ui/src/pages/ProfilePage.tsx
@@ -154,7 +154,7 @@ function DirtyBar({
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   return (
-    <Collapse in={dirty}>
+    <Collapse in={dirty} unmountOnExit>
       <InnerCard sx={{
         px: 2, py: 1.25, display: "flex", flexWrap: "wrap", alignItems: "center",
         rowGap: 1, columnGap: 1.5,
@@ -424,6 +424,7 @@ export default function ProfilePage() {
   );
   const [avatarStyle, setAvatarStyle] = React.useState<string>("");
   const [avatarSeed,  setAvatarSeed]  = React.useState<string>("");
+  const [avatarUrl,   setAvatarUrl]   = React.useState<string | undefined>(undefined);
   const [avatarOptions, setAvatarOptions] =
     React.useState<Record<string, string[]>>({});
 
@@ -441,6 +442,7 @@ export default function ProfilePage() {
       if (!profileData.auto_seasonal) setThemeName(t);
       setAvatarStyle(profileData.avatar?.style ?? "");
       setAvatarSeed(profileData.avatar?.seed ?? "");
+      setAvatarUrl(profileData.avatar?.url ?? undefined);
       setAvatarOptions(profileData.avatar?.options ?? {});
     }
   }
@@ -565,6 +567,14 @@ export default function ProfilePage() {
     setAvatarStyle(baseProfile?.avatar?.style ?? "");
     setAvatarSeed(baseProfile?.avatar?.seed ?? "");
     setAvatarOptions(baseProfile?.avatar?.options ?? {});
+  }
+
+  function onAvatarUploaded(avatar: { style: "upload"; seed: string; url?: string }) {
+    queryClient.setQueryData<UserProfile>(["profile"], (prev) => ({
+      ...(prev ?? baseProfile as UserProfile),
+      avatar: avatar as UserProfile["avatar"],
+    }));
+    enqueueSnackbar("Avatar uploaded.", { variant: "success" });
   }
 
   const setStyleWithSeed = (s: string) => {
@@ -853,6 +863,8 @@ export default function ProfilePage() {
                 style={avatarStyle} seed={avatarSeed}
                 setStyle={setStyleWithSeed} setSeed={setAvatarSeed}
                 options={avatarOptions} setOptions={setAvatarOptions}
+                photoUrl={avatarUrl}
+                onUploaded={onAvatarUploaded}
                 firstName={me.first_name} lastName={me.last_name}
                 dirtyBar={
                   <DirtyBar

--- a/suspicious-ui/src/pages/__tests__/ProfilePage.test.tsx
+++ b/suspicious-ui/src/pages/__tests__/ProfilePage.test.tsx
@@ -17,11 +17,12 @@ vi.mock("@/features/profile/api", () => ({
   updatePreferences: vi.fn(),
   updateSemanticColors: vi.fn(),
   resetSemanticColors: vi.fn(),
+  uploadAvatar: vi.fn(),
 }));
 
 
 import { getMe } from "@/api/auth";
-import { getProfile, updatePreferences } from "@/features/profile/api";
+import { getProfile, updatePreferences, uploadAvatar } from "@/features/profile/api";
 import { getStyleCategories } from "@/features/profile/avatar";
 import ProfilePage from "../ProfilePage";
 
@@ -128,6 +129,30 @@ describe("ProfilePage - Test Suite", () => {
       await waitFor(() => {
         expect(screen.getByLabelText("Eyes options")).toHaveTextContent("Auto");
       });
+    });
+
+    it("shows the uploaded photo and clears the dirty state after a successful upload", async () => {
+      const user = userEvent.setup();
+      vi.mocked(uploadAvatar).mockResolvedValue({
+        ...fixtureProfile,
+        avatar: { style: "upload", seed: "avatars/1/x.jpg", url: "https://signed" },
+      });
+
+      renderWithProviders(<ProfilePage />, { initialPath: "/profile" });
+      await user.click(await screen.findByText("Avatar"));
+
+      const file = new File(["bytes"], "photo.jpg", { type: "image/jpeg" });
+      const input = screen.getByLabelText(/upload photo/i) as HTMLInputElement;
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(uploadAvatar).toHaveBeenCalledWith(file);
+      });
+      await waitFor(() => {
+        const img = screen.getAllByRole("img").find((el) => el.getAttribute("src") === "https://signed");
+        expect(img).toBeTruthy();
+      });
+      expect(screen.queryByText("Unsaved avatar changes")).not.toBeInTheDocument();
     });
 
     it("locks the seed to the real initials when switching to the Initials style", async () => {


### PR DESCRIPTION
## Summary
- Users can upload a JPG/PNG/WebP photo as their profile avatar (`avatar.style: "upload"`), alongside the existing DiceBear-generated styles.
- Backend: Pillow validation/processing (center-crop to 512x512 JPEG q85, strip EXIF, decompression-bomb guard), MinIO storage via the shared `common.clients.get_s3_client()`, `POST /api/profile/avatar/upload/`, presigned-URL (1h) expansion on profile reads.
- Frontend: an "Upload photo" tile in the existing avatar style picker (`AvatarPanel`), and a new render branch in the shared `UserAvatar` component.
- Security hardening found and fixed during review: closed a validation bypass where `PATCH /api/profile/` could set `avatar.style: "upload"` unvalidated (the appearance endpoint was the only one originally locked down), and an unbounded pre-size-check read in the upload view (a file could be fully read into memory before the 2MB rejection ran).

Spec: `docs/superpowers/specs/2026-07-21-avatar-upload-design.md`
Plan: `docs/superpowers/plans/2026-07-21-avatar-upload.md`

## Test plan
- [x] Backend: 560/560 tests pass (`manage.py test`)
- [x] Frontend: 292/292 tests pass (`vitest run`), `tsc --noEmit` clean, `eslint` clean
- [x] Per-task review (spec compliance + code quality) for all 7 tasks — all Approved
- [x] Final whole-branch review — Ready to merge: Yes, after fixing 2 Important cross-task findings (validation bypass, unbounded read)
- [ ] Manual E2E smoke test in a running dev stack (upload a real photo, confirm it persists across refresh, confirm nav-bar avatar updates, confirm oversized/corrupt files are rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)