### PR TITLE
feat(ai-mail-analyzer): add explainability to classifier report

### DIFF
--- a/Analyzers/AIMailAnalyzer/ai_mail_classifier.py
+++ b/Analyzers/AIMailAnalyzer/ai_mail_classifier.py
@@ -4,6 +4,7 @@
 import os
 import email
 
+import numpy as np
 from cortexutils.analyzer import Analyzer
 import torch
 from sentence_transformers import SentenceTransformer
@@ -93,15 +94,28 @@ class AIMailClassifier(Analyzer):
         sub_classification_probabilities = mail_analysis.getSubClassificationProbabilities(device, [safe_model, spam_model, dangerous_model], email_embedding, classification_probabilities)
         sub_classification_info = mail_analysis.getSubClassificationInfo(sub_classification_probabilities)
 
+        # Explainability: labeled probability breakdowns + which sentences drove the call
+        classification_breakdown = mail_analysis.get_classification_breakdown(classification_probabilities)
+        sub_classification_breakdown = mail_analysis.get_sub_classification_breakdown(sub_classification_probabilities)
+        contributing_phrases = mail_analysis.get_contributing_phrases(
+            device, safe_suspicious_model, spam_dangerous_model, vectorizer,
+            mail_body,
+            classification_index=int(np.argmax(classification_probabilities)),
+            baseline_probability=float(np.max(classification_probabilities)),
+        )
+
         # Build report
         self.report({
             'malscore': str(classification_info['score']),
             'classification': classification_info['classification'],
             'confidence': str(classification_info['confidence']),
             'classification_probabilities': str(classification_probabilities),
+            'classification_breakdown': classification_breakdown,
             'sub_classification': sub_classification_info['classification'],
             'sub_classification_confidence': str(sub_classification_info['confidence']),
             'sub_classification_probabilities': str(sub_classification_probabilities),
+            'sub_classification_breakdown': sub_classification_breakdown,
+            'contributing_phrases': contributing_phrases,
             'report': {
                 'mail_file_name': self.filename,
                 'mail_file_path': self.filepath,

--- a/Analyzers/AIMailAnalyzer/mail_analysis.py
+++ b/Analyzers/AIMailAnalyzer/mail_analysis.py
@@ -1,5 +1,6 @@
 from enum import Enum
 import os
+import re
 from typing import NamedTuple
 import numpy as np
 from collections import defaultdict
@@ -194,7 +195,59 @@ def getSubClassificationInfo(global_sub_probabilities):
 
     result = {
         'classification': classification,
-        'confidence': confidence, 
+        'confidence': confidence,
     }
 
     return result
+
+def get_classification_breakdown(global_probabilities):
+    """Label the raw main-classification array by enum name, e.g.
+    {"SAFE": 0.83, "UNWANTED": 0.12, "DANGEROUS": 0.05}."""
+    return {name.name: float(p) for name, p in zip(ClassificationName, global_probabilities)}
+
+def get_sub_classification_breakdown(global_sub_probabilities):
+    """Label the raw sub-classification array by enum name."""
+    return {name.name: float(p) for name, p in zip(SubClassificationName, global_sub_probabilities)}
+
+def split_into_sentences(mail_body, max_sentences=40):
+    """Split a mail body into sentence-ish chunks for occlusion analysis.
+
+    Caps at max_sentences so a pathologically long body can't turn the
+    per-sentence re-embedding pass in get_contributing_phrases into an
+    unbounded number of model calls.
+    """
+    sentences = [s.strip() for s in re.split(r'(?<=[.!?\n])\s+', mail_body) if s.strip()]
+    return sentences[:max_sentences]
+
+def rank_phrase_impacts(sentences, impacts, top_n=5):
+    """Pair sentences with their occlusion impact, keep only sentences whose
+    removal *reduced* confidence in the predicted class (impact > 0), and
+    return the top_n by impact descending."""
+    ranked = sorted(zip(sentences, impacts), key=lambda pair: pair[1], reverse=True)
+    return [
+        {"text": text, "impact": round(float(impact), 4)}
+        for text, impact in ranked[:top_n]
+        if impact > 0
+    ]
+
+def get_contributing_phrases(device, safe_suspicious_model, spam_dangerous_model, vectorizer,
+                              mail_body, classification_index, baseline_probability, top_n=5):
+    """Sentence-level occlusion: re-embed the body with each sentence removed
+    and measure how much confidence in the predicted class drops. Sentences
+    whose removal drops confidence the most are the ones driving the
+    classification."""
+    sentences = split_into_sentences(mail_body)
+    if len(sentences) < 2:
+        return []
+
+    variants = [" ".join(sentences[:i] + sentences[i + 1:]) for i in range(len(sentences))]
+    embeddings = vectorizer.encode(variants, show_progress_bar=False)
+
+    impacts = [
+        baseline_probability - getMainClassificationProbabilities(
+            device, safe_suspicious_model, spam_dangerous_model, embedding.reshape(1, -1)
+        )[classification_index]
+        for embedding in embeddings
+    ]
+
+    return rank_phrase_impacts(sentences, impacts, top_n)

--- a/Analyzers/AIMailAnalyzer/tests/test_mail_analysis.py
+++ b/Analyzers/AIMailAnalyzer/tests/test_mail_analysis.py
@@ -36,3 +36,46 @@ def test_health_probe_uses_the_same_model_specs_as_the_classifier():
     the 4-output dangerous model, so load_state_dict always raised a shape
     mismatch there. Guard against a re-drifted, independently declared copy."""
     assert health.MODEL_SPECS is mail_analysis.MODEL_SPECS
+
+
+def test_get_classification_breakdown_labels_by_enum_name():
+    breakdown = mail_analysis.get_classification_breakdown([0.7, 0.2, 0.1])
+    assert breakdown == {"SAFE": 0.7, "UNWANTED": 0.2, "DANGEROUS": 0.1}
+
+
+def test_get_sub_classification_breakdown_labels_by_enum_name():
+    breakdown = mail_analysis.get_sub_classification_breakdown(
+        [0.1, 0.05, 0.2, 0.05, 0.5, 0.05, 0.03, 0.02]
+    )
+    assert breakdown["WHALING"] == 0.02
+    assert breakdown["CLASSIC_PHISHING"] == 0.5
+    assert len(breakdown) == len(mail_analysis.SubClassificationName)
+
+
+def test_split_into_sentences_caps_at_max_sentences():
+    body = ". ".join(f"sentence {i}" for i in range(100)) + "."
+    sentences = mail_analysis.split_into_sentences(body, max_sentences=10)
+    assert len(sentences) == 10
+
+
+def test_split_into_sentences_drops_blank_chunks():
+    sentences = mail_analysis.split_into_sentences("Hello world.  \n\n  Second sentence!")
+    assert sentences == ["Hello world.", "Second sentence!"]
+
+
+def test_rank_phrase_impacts_keeps_only_positive_impact_sorted_desc():
+    sentences = ["a", "b", "c", "d"]
+    impacts = [0.1, -0.05, 0.4, 0.0]
+    ranked = mail_analysis.rank_phrase_impacts(sentences, impacts, top_n=5)
+    assert ranked == [
+        {"text": "c", "impact": 0.4},
+        {"text": "a", "impact": 0.1},
+    ]
+
+
+def test_rank_phrase_impacts_respects_top_n():
+    sentences = ["a", "b", "c"]
+    impacts = [0.3, 0.2, 0.1]
+    ranked = mail_analysis.rank_phrase_impacts(sentences, impacts, top_n=2)
+    assert len(ranked) == 2
+    assert ranked[0]["text"] == "a"


### PR DESCRIPTION
## Summary
- Reports previously carried unlabeled `str(numpy_array)` probability dumps with no indication of why a mail was classified a given way
- Add `get_classification_breakdown`/`get_sub_classification_breakdown` to label the existing probability arrays by enum name (`SAFE`/`UNWANTED`/`DANGEROUS`, etc.) instead of an opaque stringified array
- Add `get_contributing_phrases`: sentence-level occlusion against the existing main-classification models to surface which sentences drove the score
- Wire `classification_breakdown`, `sub_classification_breakdown`, and `contributing_phrases` into the Cortex report (additive only, existing fields unchanged)

## Test plan
- [x] 9 pure-logic tests pass (`tests/test_mail_analysis.py`), including 6 new ones for the sentence-splitting/ranking helpers (no torch required)
- [x] Verified in a Docker container with numpy/pytest installed (not available on this host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)