### PR TITLE
feat(mail-header-analyzer): new rule-based header verdict analyzer

### DIFF
--- a/Analyzers/MailHeaderAnalyzer/.dockerignore
+++ b/Analyzers/MailHeaderAnalyzer/.dockerignore
@@ -1,0 +1,21 @@
+# VCS
+.git
+.gitignore
+
+# Docker
+Dockerfile
+.dockerignore
+
+# Python caches / virtualenvs
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+
+# Secrets / logs / OS cruft
+*.env
+*.log
+.DS_Store

--- a/Analyzers/MailHeaderAnalyzer/Dockerfile
+++ b/Analyzers/MailHeaderAnalyzer/Dockerfile
@@ -1,0 +1,29 @@
+#########
+# FINAL #
+#########
+
+# pull official base image
+FROM python:3.14-slim
+
+# Build-time proxy only (not baked into the running container's env).
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# set work directory
+WORKDIR /worker/
+
+# install dependencies
+COPY requirements.txt .
+RUN uv pip install --system --upgrade pip
+RUN uv pip install --system --no-cache -r requirements.txt
+
+COPY . /worker/MailHeaderAnalyzer/
+
+# Expose the application
+ENTRYPOINT ["python","MailHeaderAnalyzer/mail_header_analyzer.py"]

--- a/Analyzers/MailHeaderAnalyzer/MailHeaderAnalyzer.json
+++ b/Analyzers/MailHeaderAnalyzer/MailHeaderAnalyzer.json
@@ -1,0 +1,12 @@
+{
+  "name": "Mail_Header_Analyzer",
+  "version": "1.0",
+  "author": "THA-CERT //ECR",
+  "url": "-",
+  "license": "-",
+  "description": "Rule-based verdict on a raw email header block: SPF/DKIM/DMARC authentication results, From/Reply-To/Return-Path domain mismatches, and display-name spoofing.",
+  "dataTypeList": ["mail_header"],
+  "command": "MailHeaderAnalyzer/mail_header_analyzer.py",
+  "baseConfig": "-",
+  "configurationItems": []
+}

--- a/Analyzers/MailHeaderAnalyzer/MailHeaderAnalyzer.json
+++ b/Analyzers/MailHeaderAnalyzer/MailHeaderAnalyzer.json
@@ -1,7 +1,7 @@
 {
   "name": "Mail_Header_Analyzer",
   "version": "1.0",
-  "author": "THA-CERT //ECR",
+  "author": "THA-CERT // TBH and RBA",
   "url": "-",
   "license": "-",
   "description": "Rule-based verdict on a raw email header block: SPF/DKIM/DMARC authentication results, From/Reply-To/Return-Path domain mismatches, and display-name spoofing.",

--- a/Analyzers/MailHeaderAnalyzer/MailHeaderAnalyzer.json
+++ b/Analyzers/MailHeaderAnalyzer/MailHeaderAnalyzer.json
@@ -4,8 +4,8 @@
   "author": "THA-CERT // TBH and RBA",
   "url": "-",
   "license": "-",
-  "description": "Rule-based verdict on a raw email header block: SPF/DKIM/DMARC authentication results, From/Reply-To/Return-Path domain mismatches, and display-name spoofing.",
-  "dataTypeList": ["mail_header"],
+  "description": "Rule-based verdict on email headers: SPF/DKIM/DMARC authentication results, From/Reply-To/Return-Path domain mismatches, and display-name spoofing. Accepts either a raw header block (mail_header) or a .eml file.",
+  "dataTypeList": ["mail_header", "file"],
   "command": "MailHeaderAnalyzer/mail_header_analyzer.py",
   "baseConfig": "-",
   "configurationItems": []

--- a/Analyzers/MailHeaderAnalyzer/mail_header_analysis.py
+++ b/Analyzers/MailHeaderAnalyzer/mail_header_analysis.py
@@ -1,0 +1,133 @@
+"""Pure header-analysis logic for MailHeaderAnalyzer.
+
+No cortexutils dependency and no network calls — parses a raw email header
+block (stdlib `email` only) into a handful of deterministic phishing
+signals, then maps them to taxonomy-shaped verdicts. Kept separate from
+mail_header_analyzer.py (the cortexutils.Analyzer glue) so it's unit-testable
+with zero dependencies, matching AIMailAnalyzer's own mail_analysis.py split.
+"""
+from __future__ import annotations
+
+import re
+from email import message_from_string
+from email.utils import parseaddr
+
+_AUTH_RESULT_RE = re.compile(r'\b(spf|dkim|dmarc)\s*=\s*(\w+)', re.IGNORECASE)
+_EMBEDDED_ADDRESS_RE = re.compile(r'[\w.+-]+@[\w.-]+\.\w+')
+
+
+def parse_headers(header_text: str):
+    """Parse a raw header block into an email.message.Message."""
+    return message_from_string(header_text or "")
+
+
+def get_domain(address: str) -> str:
+    """Lowercased domain from an email address/header value, "" if unparseable."""
+    _, addr = parseaddr(address or "")
+    if "@" not in addr:
+        return ""
+    return addr.rsplit("@", 1)[1].lower()
+
+
+def parse_auth_results(msg) -> dict:
+    """Combine every Authentication-Results header's spf/dkim/dmarc verdicts.
+
+    Multiple Authentication-Results headers can be present (one per hop);
+    a mechanism counts as "pass" only if every occurrence of it passed,
+    otherwise the first non-pass verdict seen is reported, otherwise "none"
+    if the mechanism never appeared.
+    """
+    verdicts = {"spf": [], "dkim": [], "dmarc": []}
+    for header_value in msg.get_all("Authentication-Results", []):
+        for mechanism, result in _AUTH_RESULT_RE.findall(header_value):
+            verdicts[mechanism.lower()].append(result.lower())
+
+    result = {}
+    for mechanism, seen in verdicts.items():
+        if not seen:
+            result[mechanism] = "none"
+        elif all(v == "pass" for v in seen):
+            result[mechanism] = "pass"
+        else:
+            result[mechanism] = next(v for v in seen if v != "pass")
+    return result
+
+
+def check_domain_mismatch(msg, header_name: str) -> dict:
+    """Compare From's domain against another address header's domain."""
+    from_domain = get_domain(msg.get("From", ""))
+    other_header = msg.get(header_name)
+    if not other_header:
+        return {"present": False, "match": True, "from_domain": from_domain, "other_domain": ""}
+    other_domain = get_domain(other_header)
+    return {
+        "present": True,
+        "match": bool(other_domain) and other_domain == from_domain,
+        "from_domain": from_domain,
+        "other_domain": other_domain,
+    }
+
+
+def check_display_name_spoofing(msg) -> dict:
+    """True if the From display name embeds an address whose domain differs
+    from the actual From address domain (the "Legit Bank <billing@legit.com>"
+    display name on a from-domain that isn't legit.com trick)."""
+    display_name, addr = parseaddr(msg.get("From", ""))
+    from_domain = get_domain(addr)
+    embedded = _EMBEDDED_ADDRESS_RE.findall(display_name or "")
+    spoofed = [e for e in embedded if get_domain(e) and get_domain(e) != from_domain]
+    return {"spoofed": bool(spoofed), "display_name": display_name or "", "embedded_addresses": spoofed}
+
+
+def build_verdict(report: dict) -> list:
+    """Turn a raw signals report into taxonomy-shaped entries:
+    [{"level": ..., "predicate": ..., "value": ...}, ...]
+    mail_header_analyzer.py wraps each entry with self.build_taxonomy(...).
+    """
+    taxonomies = []
+
+    auth = report["auth_results"]
+    for mechanism in ("spf", "dkim", "dmarc"):
+        verdict = auth[mechanism]
+        if verdict == "pass":
+            level = "safe"
+        elif verdict == "none":
+            level = "info"
+        else:
+            level = "suspicious"
+        taxonomies.append({"level": level, "predicate": mechanism.upper(), "value": verdict})
+
+    for predicate, key in (("ReplyToMatch", "reply_to"), ("ReturnPathMatch", "return_path")):
+        check = report[key]
+        if not check["present"]:
+            level, value = "info", "absent"
+        elif check["match"]:
+            level, value = "safe", "match"
+        else:
+            level, value = "suspicious", f"{check['from_domain']} != {check['other_domain']}"
+        taxonomies.append({"level": level, "predicate": predicate, "value": value})
+
+    spoof = report["display_name_spoofing"]
+    if spoof["spoofed"]:
+        taxonomies.append({
+            "level": "malicious",
+            "predicate": "DisplayNameSpoofing",
+            "value": ", ".join(spoof["embedded_addresses"]),
+        })
+    else:
+        taxonomies.append({"level": "safe", "predicate": "DisplayNameSpoofing", "value": "none"})
+
+    return taxonomies
+
+
+def analyze(header_text: str) -> dict:
+    """Full pipeline: raw header text -> signals + taxonomy-shaped verdict."""
+    msg = parse_headers(header_text)
+    report = {
+        "auth_results": parse_auth_results(msg),
+        "reply_to": check_domain_mismatch(msg, "Reply-To"),
+        "return_path": check_domain_mismatch(msg, "Return-Path"),
+        "display_name_spoofing": check_display_name_spoofing(msg),
+    }
+    report["taxonomies"] = build_verdict(report)
+    return report

--- a/Analyzers/MailHeaderAnalyzer/mail_header_analysis.py
+++ b/Analyzers/MailHeaderAnalyzer/mail_header_analysis.py
@@ -1,11 +1,3 @@
-"""Pure header-analysis logic for MailHeaderAnalyzer.
-
-No cortexutils dependency and no network calls — parses a raw email header
-block (stdlib `email` only) into a handful of deterministic phishing
-signals, then maps them to taxonomy-shaped verdicts. Kept separate from
-mail_header_analyzer.py (the cortexutils.Analyzer glue) so it's unit-testable
-with zero dependencies, matching AIMailAnalyzer's own mail_analysis.py split.
-"""
 from __future__ import annotations
 
 import re

--- a/Analyzers/MailHeaderAnalyzer/mail_header_analysis.py
+++ b/Analyzers/MailHeaderAnalyzer/mail_header_analysis.py
@@ -120,9 +120,10 @@ def build_verdict(report: dict) -> list:
     return taxonomies
 
 
-def analyze(header_text: str) -> dict:
-    """Full pipeline: raw header text -> signals + taxonomy-shaped verdict."""
-    msg = parse_headers(header_text)
+def analyze_message(msg) -> dict:
+    """Full pipeline on an already-parsed email.message.Message: signals +
+    taxonomy-shaped verdict. Works the same whether msg came from a bare
+    header block or a full .eml (only header access is used, never body)."""
     report = {
         "auth_results": parse_auth_results(msg),
         "reply_to": check_domain_mismatch(msg, "Reply-To"),
@@ -131,3 +132,8 @@ def analyze(header_text: str) -> dict:
     }
     report["taxonomies"] = build_verdict(report)
     return report
+
+
+def analyze(header_text: str) -> dict:
+    """Full pipeline: raw header text -> signals + taxonomy-shaped verdict."""
+    return analyze_message(parse_headers(header_text))

--- a/Analyzers/MailHeaderAnalyzer/mail_header_analyzer.py
+++ b/Analyzers/MailHeaderAnalyzer/mail_header_analyzer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Author : THA-CERT //ECR
+# Author : THA-CERT // TBH and RBA
 
 from cortexutils.analyzer import Analyzer
 

--- a/Analyzers/MailHeaderAnalyzer/mail_header_analyzer.py
+++ b/Analyzers/MailHeaderAnalyzer/mail_header_analyzer.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Author : THA-CERT //ECR
+
+from cortexutils.analyzer import Analyzer
+
+import mail_header_analysis
+
+
+class MailHeaderAnalyzer(Analyzer):
+    def __init__(self):
+        Analyzer.__init__(self)
+
+    def summary(self, raw):
+        taxonomies = [
+            self.build_taxonomy(t["level"], "MailHeaderAnalyzer", t["predicate"], t["value"])
+            for t in raw.get("taxonomies", [])
+        ]
+        return {"taxonomies": taxonomies}
+
+    def run(self):
+        Analyzer.run(self)
+
+        if self.data_type != "mail_header":
+            self.error(f"Unsupported data type: {self.data_type}. Expected mail_header.")
+            return
+
+        header_text = self.get_data()
+        if not header_text:
+            self.error("No header data provided.")
+            return
+
+        self.report(mail_header_analysis.analyze(header_text))
+
+
+if __name__ == "__main__":
+    MailHeaderAnalyzer().run()

--- a/Analyzers/MailHeaderAnalyzer/mail_header_analyzer.py
+++ b/Analyzers/MailHeaderAnalyzer/mail_header_analyzer.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # Author : THA-CERT // TBH and RBA
 
+import email
+import email.policy
+
 from cortexutils.analyzer import Analyzer
 
 import mail_header_analysis
@@ -17,19 +20,39 @@ class MailHeaderAnalyzer(Analyzer):
         ]
         return {"taxonomies": taxonomies}
 
+    def _get_message(self):
+        """Return a parsed email.message.Message, or None (calls self.error itself)."""
+        if self.data_type == "mail_header":
+            header_text = self.get_data()
+            if not header_text:
+                self.error("No header data provided.")
+                return None
+            return mail_header_analysis.parse_headers(header_text)
+
+        if self.data_type == "file":
+            filename = self.get_param("filename", "")
+            if not filename.lower().endswith(".eml"):
+                self.error("Only .eml files are supported for the file data type.")
+                return None
+            filepath = self.get_param("file", None, "File is missing")
+            try:
+                with open(filepath, "rb") as f:
+                    return email.message_from_binary_file(f, policy=email.policy.default)
+            except Exception as e:
+                self.error(f"Failed to parse .eml file: {e}")
+                return None
+
+        self.error(f"Unsupported data type: {self.data_type}. Expected mail_header or file (.eml).")
+        return None
+
     def run(self):
         Analyzer.run(self)
 
-        if self.data_type != "mail_header":
-            self.error(f"Unsupported data type: {self.data_type}. Expected mail_header.")
+        msg = self._get_message()
+        if msg is None:
             return
 
-        header_text = self.get_data()
-        if not header_text:
-            self.error("No header data provided.")
-            return
-
-        self.report(mail_header_analysis.analyze(header_text))
+        self.report(mail_header_analysis.analyze_message(msg))
 
 
 if __name__ == "__main__":

--- a/Analyzers/MailHeaderAnalyzer/requirements.txt
+++ b/Analyzers/MailHeaderAnalyzer/requirements.txt
@@ -1,0 +1,1 @@
+cortexutils

--- a/Analyzers/MailHeaderAnalyzer/tests/test_mail_header_analysis.py
+++ b/Analyzers/MailHeaderAnalyzer/tests/test_mail_header_analysis.py
@@ -1,0 +1,128 @@
+"""Pure-logic tests for mail_header_analysis.py — stdlib `email` only, no
+cortexutils/network dependency needed, so these run without the Docker image."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import mail_header_analysis as mha  # noqa: E402
+
+
+def _headers(*lines):
+    return "\n".join(lines) + "\n"
+
+
+def test_parse_auth_results_all_pass():
+    msg = mha.parse_headers(_headers(
+        "Authentication-Results: mx.example.com; spf=pass smtp.mailfrom=a.com; "
+        "dkim=pass header.d=a.com; dmarc=pass"
+    ))
+    assert mha.parse_auth_results(msg) == {"spf": "pass", "dkim": "pass", "dmarc": "pass"}
+
+
+def test_parse_auth_results_missing_header_is_none():
+    msg = mha.parse_headers(_headers("Subject: hi"))
+    assert mha.parse_auth_results(msg) == {"spf": "none", "dkim": "none", "dmarc": "none"}
+
+
+def test_parse_auth_results_mixed_across_multiple_headers_keeps_worst():
+    msg = mha.parse_headers(_headers(
+        "Authentication-Results: mx1.example.com; spf=pass; dkim=none",
+        "Authentication-Results: mx2.example.com; spf=fail; dkim=pass; dmarc=fail",
+    ))
+    result = mha.parse_auth_results(msg)
+    assert result["spf"] == "fail"
+    assert result["dkim"] == "none"
+    assert result["dmarc"] == "fail"
+
+
+def test_get_domain_extracts_lowercased_domain():
+    assert mha.get_domain("Alice <Alice@Example.COM>") == "example.com"
+
+
+def test_get_domain_returns_empty_for_unparseable():
+    assert mha.get_domain("not an address") == ""
+
+
+def test_check_domain_mismatch_flags_different_domains():
+    msg = mha.parse_headers(_headers(
+        "From: Billing <billing@legit-bank.com>",
+        "Reply-To: attacker@evil.com",
+    ))
+    result = mha.check_domain_mismatch(msg, "Reply-To")
+    assert result == {
+        "present": True, "match": False,
+        "from_domain": "legit-bank.com", "other_domain": "evil.com",
+    }
+
+
+def test_check_domain_mismatch_matching_domains():
+    msg = mha.parse_headers(_headers(
+        "From: Billing <billing@legit-bank.com>",
+        "Reply-To: support@legit-bank.com",
+    ))
+    assert mha.check_domain_mismatch(msg, "Reply-To")["match"] is True
+
+
+def test_check_domain_mismatch_absent_header():
+    msg = mha.parse_headers(_headers("From: billing@legit-bank.com"))
+    result = mha.check_domain_mismatch(msg, "Return-Path")
+    assert result["present"] is False
+    assert result["match"] is True
+
+
+def test_display_name_spoofing_detected():
+    msg = mha.parse_headers(_headers(
+        'From: "billing@legit-bank.com" <attacker@evil.com>'
+    ))
+    result = mha.check_display_name_spoofing(msg)
+    assert result["spoofed"] is True
+    assert "billing@legit-bank.com" in result["embedded_addresses"]
+
+
+def test_display_name_spoofing_not_flagged_when_no_embedded_address():
+    msg = mha.parse_headers(_headers("From: Billing Team <billing@legit-bank.com>"))
+    assert mha.check_display_name_spoofing(msg)["spoofed"] is False
+
+
+def test_build_verdict_all_pass_and_matching_is_safe():
+    report = {
+        "auth_results": {"spf": "pass", "dkim": "pass", "dmarc": "pass"},
+        "reply_to": {"present": True, "match": True, "from_domain": "a.com", "other_domain": "a.com"},
+        "return_path": {"present": True, "match": True, "from_domain": "a.com", "other_domain": "a.com"},
+        "display_name_spoofing": {"spoofed": False, "display_name": "A", "embedded_addresses": []},
+    }
+    taxonomies = mha.build_verdict(report)
+    levels = {t["predicate"]: t["level"] for t in taxonomies}
+    assert levels["SPF"] == "safe"
+    assert levels["DKIM"] == "safe"
+    assert levels["DMARC"] == "safe"
+    assert levels["ReplyToMatch"] == "safe"
+    assert levels["ReturnPathMatch"] == "safe"
+    assert levels["DisplayNameSpoofing"] == "safe"
+
+
+def test_build_verdict_spoofing_is_malicious():
+    report = {
+        "auth_results": {"spf": "none", "dkim": "none", "dmarc": "none"},
+        "reply_to": {"present": False, "match": True, "from_domain": "a.com", "other_domain": ""},
+        "return_path": {"present": False, "match": True, "from_domain": "a.com", "other_domain": ""},
+        "display_name_spoofing": {"spoofed": True, "display_name": "x", "embedded_addresses": ["billing@a.com"]},
+    }
+    taxonomies = mha.build_verdict(report)
+    levels = {t["predicate"]: t["level"] for t in taxonomies}
+    assert levels["DisplayNameSpoofing"] == "malicious"
+    assert levels["SPF"] == "info"
+
+
+def test_analyze_end_to_end():
+    header_text = _headers(
+        "From: \"Legit Bank\" <billing@legit-bank.com>",
+        "Reply-To: attacker@evil.com",
+        "Authentication-Results: mx.example.com; spf=fail; dkim=fail; dmarc=fail",
+    )
+    report = mha.analyze(header_text)
+    assert report["auth_results"]["spf"] == "fail"
+    assert report["reply_to"]["match"] is False
+    predicates = {t["predicate"] for t in report["taxonomies"]}
+    assert {"SPF", "DKIM", "DMARC", "ReplyToMatch", "ReturnPathMatch", "DisplayNameSpoofing"} == predicates

--- a/Analyzers/MailHeaderAnalyzer/tests/test_mail_header_analysis.py
+++ b/Analyzers/MailHeaderAnalyzer/tests/test_mail_header_analysis.py
@@ -1,5 +1,7 @@
 """Pure-logic tests for mail_header_analysis.py — stdlib `email` only, no
 cortexutils/network dependency needed, so these run without the Docker image."""
+import email
+import email.policy
 import sys
 from pathlib import Path
 
@@ -126,3 +128,23 @@ def test_analyze_end_to_end():
     assert report["reply_to"]["match"] is False
     predicates = {t["predicate"] for t in report["taxonomies"]}
     assert {"SPF", "DKIM", "DMARC", "ReplyToMatch", "ReturnPathMatch", "DisplayNameSpoofing"} == predicates
+
+
+def test_analyze_message_works_on_a_full_eml_not_just_bare_headers():
+    """The .eml data-type entry point parses a full message (headers + body)
+    via email.message_from_bytes — analyze_message must give the same result
+    as the bare-header-block entry point since it only ever touches headers."""
+    eml_bytes = (
+        b'From: "Legit Bank" <billing@legit-bank.com>\r\n'
+        b"Reply-To: attacker@evil.com\r\n"
+        b"Authentication-Results: mx.example.com; spf=fail; dkim=fail; dmarc=fail\r\n"
+        b"Subject: Urgent action required\r\n"
+        b"Content-Type: text/plain\r\n"
+        b"\r\n"
+        b"Click here to verify your account.\r\n"
+    )
+    msg = email.message_from_bytes(eml_bytes, policy=email.policy.default)
+    report = mha.analyze_message(msg)
+    assert report["auth_results"] == {"spf": "fail", "dkim": "fail", "dmarc": "fail"}
+    assert report["reply_to"]["match"] is False
+    assert report["reply_to"]["from_domain"] == "legit-bank.com"

--- a/Analyzers/analyzers.json
+++ b/Analyzers/analyzers.json
@@ -12,5 +12,19 @@
         "baseConfig": "-",
         "configurationItems": [],
         "dockerImage": "aimailanalyzer:v2"
+    },
+    {
+        "name": "Mail_Header_Analyzer",
+        "version": "1.0",
+        "author": "THA-CERT //ECR",
+        "url": "-",
+        "license": "-",
+        "description": "-",
+        "dataTypeList": [
+            "mail_header"
+        ],
+        "baseConfig": "-",
+        "configurationItems": [],
+        "dockerImage": "mailheaderanalyzer:v1"
     }
 ]

--- a/Analyzers/analyzers.json
+++ b/Analyzers/analyzers.json
@@ -16,7 +16,7 @@
     {
         "name": "Mail_Header_Analyzer",
         "version": "1.0",
-        "author": "THA-CERT //ECR",
+        "author": "THA-CERT // TBH and RBA",
         "url": "-",
         "license": "-",
         "description": "-",

--- a/Analyzers/thehive-templates/Mail_Header_Analyzer_1_0/long.html
+++ b/Analyzers/thehive-templates/Mail_Header_Analyzer_1_0/long.html
@@ -1,0 +1,77 @@
+<div class="panel panel-info" ng-if="success">
+    <div class="panel-heading bg-primary text-white">
+        <h4 class="panel-title">Mail Header Analysis</h4>
+    </div>
+    <div class="panel-body">
+
+        <!-- Authentication Results -->
+        <h4 class="text-info">Authentication Results</h4>
+        <table class="table table-striped table-bordered table-condensed">
+            <thead>
+                <tr>
+                    <th>Mechanism</th>
+                    <th>Verdict</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="mechanism in ['spf', 'dkim', 'dmarc']">
+                    <td>{{mechanism.toUpperCase()}}</td>
+                    <td>
+                        <span ng-if="content.auth_results[mechanism] === 'pass'" class="label label-success">{{content.auth_results[mechanism]}}</span>
+                        <span ng-if="content.auth_results[mechanism] === 'none'" class="label label-default">{{content.auth_results[mechanism]}}</span>
+                        <span ng-if="content.auth_results[mechanism] !== 'pass' && content.auth_results[mechanism] !== 'none'" class="label label-danger">{{content.auth_results[mechanism]}}</span>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+
+        <hr>
+
+        <!-- Address Consistency -->
+        <h4 class="text-info">Address Consistency</h4>
+        <dl class="dl-horizontal">
+            <dt>Reply-To:</dt>
+            <dd>
+                <span ng-if="!content.reply_to.present" class="label label-default">absent</span>
+                <span ng-if="content.reply_to.present && content.reply_to.match" class="label label-success">matches From ({{content.reply_to.from_domain}})</span>
+                <span ng-if="content.reply_to.present && !content.reply_to.match" class="label label-danger">{{content.reply_to.from_domain}} != {{content.reply_to.other_domain}}</span>
+            </dd>
+            <dt>Return-Path:</dt>
+            <dd>
+                <span ng-if="!content.return_path.present" class="label label-default">absent</span>
+                <span ng-if="content.return_path.present && content.return_path.match" class="label label-success">matches From ({{content.return_path.from_domain}})</span>
+                <span ng-if="content.return_path.present && !content.return_path.match" class="label label-danger">{{content.return_path.from_domain}} != {{content.return_path.other_domain}}</span>
+            </dd>
+        </dl>
+
+        <hr>
+
+        <!-- Display Name Spoofing -->
+        <h4 class="text-info">Display Name Spoofing</h4>
+        <dl class="dl-horizontal">
+            <dt>Display name:</dt>
+            <dd>{{content.display_name_spoofing.display_name || '(none)'}}</dd>
+            <dt>Verdict:</dt>
+            <dd>
+                <span ng-if="!content.display_name_spoofing.spoofed" class="label label-success">No spoofing detected</span>
+                <span ng-if="content.display_name_spoofing.spoofed" class="label label-danger">Spoofed address embedded in display name</span>
+            </dd>
+        </dl>
+        <div ng-if="content.display_name_spoofing.embedded_addresses.length" style="margin-top:5px;">
+            <strong class="text-danger">Embedded addresses:</strong>
+            <ul style="margin-bottom:0; padding-left:20px;">
+                <li ng-repeat="addr in content.display_name_spoofing.embedded_addresses" class="text-danger">{{addr}}</li>
+            </ul>
+        </div>
+
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{artifact.data | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        <p>{{content.errorMessage}}</p>
+    </div>
+</div>

--- a/Analyzers/thehive-templates/Mail_Header_Analyzer_1_0/short.html
+++ b/Analyzers/thehive-templates/Mail_Header_Analyzer_1_0/short.html
@@ -1,0 +1,3 @@
+<span class="label" ng-repeat="t in content.taxonomies" ng-class="{'info': 'label-info', 'safe': 'label-success', 'suspicious': 'label-warning', 'malicious':'label-danger'}[t.level]">
+    {{t.namespace}}:{{t.predicate}}="{{t.value}}"
+</span>


### PR DESCRIPTION
## Summary
- Suspicious already had a complete, wired pipeline for a `mail_header` Cortex data type (job dispatch, `MailHeader` model, case-score rollup) but no analyzer ever declared `dataTypeList: ["mail_header"]`, so those jobs ran against zero analyzers
- Add `MailHeaderAnalyzer`: a lightweight rule-based Cortex analyzer (no ML, no tar/file handling) checking SPF/DKIM/DMARC (from `Authentication-Results`), From/Reply-To/Return-Path domain mismatches, and display-name spoofing
- Each signal is a `build_taxonomy()` entry, following the same convention as TheHive's public `DomainMailSPFDMARC` analyzer, so Suspicious's existing `DefaultTaxonomyParser` aggregates them with no bespoke backend parser needed
- Also accepts `.eml` files (`dataType: "file"`) for portability to stock TheHive/Cortex instances, since `mail_header` is a Suspicious-specific custom data type — `Analyzers/analyzers.json` (the live org catalog this deployment mounts) intentionally still only registers `mail_header`, since Suspicious's own `"file"` jobs are always `AI_Mail_Analyzer`'s tar bundle
- Added `Analyzers/thehive-templates/Mail_Header_Analyzer_1_0/{short,long}.html` report templates so results render properly in TheHive instead of raw JSON

## Test plan
- [x] 14 pure-logic tests pass (`tests/test_mail_header_analysis.py`)
- [x] Smoke-tested against the real `cortexutils` job-directory protocol in a built Docker image: `mail_header` path, `.eml` path (correct verdict + auto-extracted domain artifacts), and a non-`.eml` file failing cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)