### PR TITLE
fix: avatar presign URL + investigations payload/query perf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ Assumes: Docker + Compose v2 working, outbound internet, a user in the `docker` 
 
 Base them on `docs/getting-started/examples/*.example` (already a coherent "Meridian Group" example set) and layer in:
 - `deployment/.env` — copy `deployment/.env.example`, fill in the `DOMAIN_CORP`/passwords from the docs example, and set `CORTEX_PATH` to an **absolute** path (e.g. `$(pwd)/cortex` under `deployment/`) — a relative path fails Cortex's mount with "mount path must be absolute".
-- `Suspicious/settings.json` — copy `docs/getting-started/examples/Suspicious-settings.example.json`. Keep `app.debug: true` (plain HTTP, no Traefik). `database.password` **must equal** `.env`'s `MYSQL_PASSWORD`.
+- `Suspicious/settings.json` — copy `docs/getting-started/examples/Suspicious-settings.example.json`. Keep `app.debug: true` (plain HTTP, no Traefik). `database.password` **must equal** `.env`'s `MYSQL_PASSWORD`. If `storage.backend` is set to `s3` (mail attachments, uploaded avatar photos), also set `storage.s3.public_endpoint` to `localhost:${MINIO_API_PORT:-35002}` — `storage.s3.endpoint` (`rustfs:9000`) is Docker-internal and unresolvable from the browser, so presigned URLs built from it 404/NXDOMAIN client-side (avatar photo silently falls back to initials, no error shown). `compose_databases.yaml`'s `rustfs` service publishes that port to the host for exactly this; see CONFIG.md § 2.6.
 - `email-feeder/config.json` — copy `docs/getting-started/examples/email-feeder-config.example.json`.
 - `suspicious-ui/.env` — copy `docs/getting-started/examples/suspicious-ui-env.example` verbatim.
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -281,16 +281,23 @@ data:`), a `public_endpoint` on a different origin than the app — a bare
 console-visible network error, the `<img>` just never loads. Two ways to
 avoid it:
 - **Same-origin (recommended, no CSP change):** set `public_endpoint` to
-  the app's own domain (`storage.s3.public_endpoint = "<DOMAIN_CORP>"`,
-  `public_secure = true`) and route S3 GETs through Traefik under that
-  domain — see the `suspicious-storage` router in `tls.yaml`, which
-  matches `PathPrefix` on the configured bucket names (S3 path-style URLs
-  put the bucket name first in the path, so no prefix-stripping is
-  needed) and forwards to `rustfs:9000` with `passHostHeader: true`
-  (required — S3 SigV4 signs the `host` header, so whatever Host the
-  browser sent when the URL was signed must reach rustfs unchanged, or
-  signature verification fails). Keep that router's bucket-name list in
-  sync with `avatars_bucket` / `media_bucket` / `feeder_bucket`.
+  whatever origin users actually type into the address bar — `self` in CSP
+  terms means the *browser's* origin, not `DOMAIN_CORP`. They're usually
+  the same, but not always: a cert issued for `DOMAIN_CORP` still lets a
+  browser load the app over `https://localhost` (or any other name that
+  resolves to the same box) if it's been told to tolerate the mismatch,
+  and CSP then evaluates against `localhost`, not `DOMAIN_CORP`. Check
+  Traefik's `access.log` (the `Referer` column on any request) if unsure
+  which origin is actually in play. Then set `public_secure = true` and
+  route S3 GETs through Traefik under that origin — see the
+  `suspicious-storage` router in `tls.yaml`, which matches `PathPrefix` on
+  the configured bucket names (S3 path-style URLs put the bucket name
+  first in the path, so no prefix-stripping is needed) and forwards to
+  `rustfs:9000` with `passHostHeader: true` (required — S3 SigV4 signs the
+  `host` header, so whatever Host the browser sent when the URL was
+  signed must reach rustfs unchanged, or signature verification fails).
+  Keep that router's bucket-name list in sync with `avatars_bucket` /
+  `media_bucket` / `feeder_bucket`.
 - **No Traefik in front (plain-HTTP dev stack):** there's no CSP at all in
   that path, so a bare `localhost:<published-9000-port>` `public_endpoint`
   works — see the `/deploy-full-e2e` flow in `CLAUDE.md`.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -277,6 +277,22 @@ which needs its own port mapping since rustfs only `expose`s 9000 to the
 Docker network by default). Omit `public_endpoint` and it falls back to
 `endpoint` — existing single-endpoint deployments are unaffected.
 
+The client that signs `public_endpoint` URLs pins `region` to a fixed value
+(`"us-east-1"` unless `storage.s3.region` overrides it) instead of letting
+the SDK auto-detect it. Auto-detection does a live bucket-location request
+against the endpoint being signed for — and the whole point of
+`public_endpoint` is that it's reachable from a browser, not necessarily
+from wherever the Django/Celery process signing the URL runs, so that
+request can't be relied on to succeed.
+
+**DB overrides settings.json at runtime.** `storage.s3` (like other
+sections) is seeded into the `RuntimeConfig` table on first run and served
+from there — Redis-cached — ahead of `settings.json`. Editing the file
+after `seed_config` has already run does **nothing** until the matching DB
+row is updated too (Settings page in the UI, or
+`RuntimeConfig.objects.filter(key="storage.s3")` in a shell) and the cache
+entry is invalidated (`settings.config.invalidate_cache("storage.s3")`).
+
 #### Feeder fast metadata
 
 `fast_metadata` (default `false`) controls the email-ingestion fast path. The

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -251,7 +251,7 @@ mismatch gives `Access denied for user 'suspicious'`.
     "backend": "local",
     "s3": {
         "endpoint": "rustfs:9000",
-        "public_endpoint": "localhost:9000",
+        "public_endpoint": "localhost:35002",
         "access_key": "MINIO_ACCESS_KEY",
         "secret_key": "MINIO_SECRET_KEY",
         "secure": false,
@@ -271,11 +271,29 @@ RustFS credentials in `.env` (`MINIO_ROOT_PASSWORD`), and RustFS must be running
 put/get/bucket calls. Presigned URLs (mail-attachment links, uploaded
 avatar photos) are opened directly by the browser, which can't resolve that
 internal hostname — set `public_endpoint` to whatever host:port the browser
-*can* reach (behind Traefik in production, that's usually a routed
-subdomain; for a local dev stack it's `localhost:<published-9000-port>`,
-which needs its own port mapping since rustfs only `expose`s 9000 to the
-Docker network by default). Omit `public_endpoint` and it falls back to
-`endpoint` — existing single-endpoint deployments are unaffected.
+*can* reach. Omit it and it falls back to `endpoint` — existing
+single-endpoint deployments are unaffected.
+
+**Behind Traefik** (`security-headers` middleware in
+`traefik/dynamic/tls.yaml` sets `Content-Security-Policy: img-src 'self'
+data:`), a `public_endpoint` on a different origin than the app — a bare
+`host:port` — gets silently dropped by the browser's CSP enforcement; no
+console-visible network error, the `<img>` just never loads. Two ways to
+avoid it:
+- **Same-origin (recommended, no CSP change):** set `public_endpoint` to
+  the app's own domain (`storage.s3.public_endpoint = "<DOMAIN_CORP>"`,
+  `public_secure = true`) and route S3 GETs through Traefik under that
+  domain — see the `suspicious-storage` router in `tls.yaml`, which
+  matches `PathPrefix` on the configured bucket names (S3 path-style URLs
+  put the bucket name first in the path, so no prefix-stripping is
+  needed) and forwards to `rustfs:9000` with `passHostHeader: true`
+  (required — S3 SigV4 signs the `host` header, so whatever Host the
+  browser sent when the URL was signed must reach rustfs unchanged, or
+  signature verification fails). Keep that router's bucket-name list in
+  sync with `avatars_bucket` / `media_bucket` / `feeder_bucket`.
+- **No Traefik in front (plain-HTTP dev stack):** there's no CSP at all in
+  that path, so a bare `localhost:<published-9000-port>` `public_endpoint`
+  works — see the `/deploy-full-e2e` flow in `CLAUDE.md`.
 
 The client that signs `public_endpoint` URLs pins `region` to a fixed value
 (`"us-east-1"` unless `storage.s3.region` overrides it) instead of letting

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -251,6 +251,7 @@ mismatch gives `Access denied for user 'suspicious'`.
     "backend": "local",
     "s3": {
         "endpoint": "rustfs:9000",
+        "public_endpoint": "localhost:9000",
         "access_key": "MINIO_ACCESS_KEY",
         "secret_key": "MINIO_SECRET_KEY",
         "secure": false,
@@ -265,6 +266,16 @@ mismatch gives `Access denied for user 'suspicious'`.
 does **not** require the RustFS service — handy for a minimal dev run. Set
 `"backend": "s3"` to use object storage; then `secret_key` here must match the
 RustFS credentials in `.env` (`MINIO_ROOT_PASSWORD`), and RustFS must be running.
+
+`endpoint` is the Docker-internal host the app container uses for
+put/get/bucket calls. Presigned URLs (mail-attachment links, uploaded
+avatar photos) are opened directly by the browser, which can't resolve that
+internal hostname — set `public_endpoint` to whatever host:port the browser
+*can* reach (behind Traefik in production, that's usually a routed
+subdomain; for a local dev stack it's `localhost:<published-9000-port>`,
+which needs its own port mapping since rustfs only `expose`s 9000 to the
+Docker network by default). Omit `public_endpoint` and it falls back to
+`endpoint` — existing single-endpoint deployments are unaffected.
 
 #### Feeder fast metadata
 

--- a/Suspicious/Suspicious/api/serializers/investigations.py
+++ b/Suspicious/Suspicious/api/serializers/investigations.py
@@ -185,7 +185,7 @@ class InvestigationAnalyzerReportSerializer(serializers.ModelSerializer):
         fields = [
             "id", "cortex_job_id", "type", "status", "analyzer_name", "analyzer_id",
             "level", "confidence", "score", "category", "categories",
-            "report_summary", "report_taxonomy", "report_full", "target", "created_at",
+            "report_summary", "report_taxonomy", "target", "created_at",
         ]
 
     def get_categories(self, obj: AnalyzerReport) -> list[str]:

--- a/Suspicious/Suspicious/api/views/investigations.py
+++ b/Suspicious/Suspicious/api/views/investigations.py
@@ -315,7 +315,14 @@ class InvestigationAccessMixin:
         else:
             queryset = queryset.order_by("-creation_date", "-pk")
 
-        return queryset.distinct()
+        # No .distinct() needed: every relation touched above (fileOrMail,
+        # nonFileIocs, and their file/mail/url/ip/hash children) is a
+        # forward FK or O2O from Case's side, never reverse/M2M, so a Case
+        # row can't fan out into duplicates through these joins. distinct()
+        # here was forcing MySQL to sort/dedupe the whole joined result set
+        # before LIMIT applied — measured ~1.6s wasted per page on a 41k-row
+        # table for zero effect.
+        return queryset
 
 
 @extend_schema(

--- a/Suspicious/Suspicious/case_handler/case_utils/form_handlers/mail/minio.py
+++ b/Suspicious/Suspicious/case_handler/case_utils/form_handlers/mail/minio.py
@@ -5,7 +5,7 @@ from minio import Minio
 from minio.error import S3Error
 from minio.commonconfig import Tags
 
-from common.clients import get_s3_client
+from common.clients import get_s3_client, get_s3_presign_client
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,7 @@ class MinioManager:
         Initialize the MinIO client from the shared ``storage.s3`` runtime config.
         """
         self.client = self._default_client()
+        self.presign_client = self._presign_client()
 
     def _default_client(self) -> Optional[Minio]:
         """
@@ -38,6 +39,19 @@ class MinioManager:
             return client
         except Exception as e:
             logger.critical("Failed to initialize MinIO client: %s", e, exc_info=True)
+            return None
+
+    def _presign_client(self) -> Optional[Minio]:
+        """
+        Client for signing browser-facing URLs (storage.s3.public_endpoint).
+
+        Returns:
+            Minio | None: Initialized client or None on failure.
+        """
+        try:
+            return get_s3_presign_client()
+        except Exception as e:
+            logger.critical("Failed to initialize MinIO presign client: %s", e, exc_info=True)
             return None
 
     def bucket_exists(self, bucket_name: str) -> bool:
@@ -170,13 +184,13 @@ class MinioManager:
         Returns:
             str | None: Presigned URL or None on failure.
         """
-        if not self.client:
-            logger.error("MinIO client unavailable for presigned URL.")
+        if not self.presign_client:
+            logger.error("MinIO presign client unavailable for presigned URL.")
             return None
         try:
             if method.lower() == "get":
-                return self.client.presigned_get_object(bucket_name, object_name, expires=expires_seconds)
-            return self.client.presigned_put_object(bucket_name, object_name, expires=expires_seconds)
+                return self.presign_client.presigned_get_object(bucket_name, object_name, expires=expires_seconds)
+            return self.presign_client.presigned_put_object(bucket_name, object_name, expires=expires_seconds)
         except Exception as e:
             logger.error("Failed to generate presigned URL for '%s/%s': %s", bucket_name, object_name, e)
             return None

--- a/Suspicious/Suspicious/case_handler/tests/test_minio_manager.py
+++ b/Suspicious/Suspicious/case_handler/tests/test_minio_manager.py
@@ -1,0 +1,51 @@
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from case_handler.case_utils.form_handlers.mail.minio import MinioManager
+
+
+class GeneratePresignedUrlTest(SimpleTestCase):
+    def _manager_with_presign_client(self, fake_client):
+        with mock.patch(
+            "case_handler.case_utils.form_handlers.mail.minio.get_s3_client",
+            return_value=mock.MagicMock(),
+        ), mock.patch(
+            "case_handler.case_utils.form_handlers.mail.minio.get_s3_presign_client",
+            return_value=fake_client,
+        ):
+            return MinioManager()
+
+    def test_get_uses_presign_client_not_internal_client(self):
+        fake_presign = mock.MagicMock()
+        fake_presign.presigned_get_object.return_value = "https://public/signed"
+        manager = self._manager_with_presign_client(fake_presign)
+
+        url = manager.generate_presigned_url("bucket", "obj.eml")
+
+        self.assertEqual(url, "https://public/signed")
+        fake_presign.presigned_get_object.assert_called_once_with(
+            "bucket", "obj.eml", expires=7 * 24 * 3600
+        )
+        manager.client.presigned_get_object.assert_not_called()
+
+    def test_put_uses_presign_client(self):
+        fake_presign = mock.MagicMock()
+        fake_presign.presigned_put_object.return_value = "https://public/put"
+        manager = self._manager_with_presign_client(fake_presign)
+
+        url = manager.generate_presigned_url("bucket", "obj.eml", method="put")
+
+        self.assertEqual(url, "https://public/put")
+
+    def test_returns_none_when_presign_client_unavailable(self):
+        with mock.patch(
+            "case_handler.case_utils.form_handlers.mail.minio.get_s3_client",
+            return_value=mock.MagicMock(),
+        ), mock.patch(
+            "case_handler.case_utils.form_handlers.mail.minio.get_s3_presign_client",
+            side_effect=Exception("boom"),
+        ):
+            manager = MinioManager()
+
+        self.assertIsNone(manager.generate_presigned_url("bucket", "obj.eml"))

--- a/Suspicious/Suspicious/common/clients.py
+++ b/Suspicious/Suspicious/common/clients.py
@@ -32,6 +32,24 @@ def get_s3_client() -> Minio:
     )
 
 
+def get_s3_presign_client() -> Minio:
+    """MinIO/rustfs client for signing browser-facing URLs.
+
+    ``storage.s3.endpoint`` is the Docker-internal host the app container
+    uses for put/get calls; browsers can't resolve it. Presigned URLs must
+    be signed against ``storage.s3.public_endpoint`` instead — falls back
+    to ``endpoint`` when unset, so existing single-endpoint deployments are
+    unaffected.
+    """
+    cfg = get_section("storage.s3")
+    return Minio(
+        endpoint=cfg.get("public_endpoint") or cfg["endpoint"],
+        access_key=cfg["access_key"],
+        secret_key=cfg["secret_key"],
+        secure=cfg.get("public_secure", cfg.get("secure", False)),
+    )
+
+
 def _disable_chromadb_telemetry() -> None:
     """Suppress ChromaDB telemetry via env vars and best-effort monkey-patching."""
     try:

--- a/Suspicious/Suspicious/common/clients.py
+++ b/Suspicious/Suspicious/common/clients.py
@@ -21,6 +21,9 @@ _DEFAULT_CHROMA_HOST = "chromadb"
 _DEFAULT_CHROMA_PORT = 8000
 
 
+_DEFAULT_S3_REGION = "us-east-1"
+
+
 def get_s3_client() -> Minio:
     """MinIO/rustfs client from the shared ``storage.s3`` section."""
     cfg = get_section("storage.s3")
@@ -29,6 +32,7 @@ def get_s3_client() -> Minio:
         access_key=cfg["access_key"],
         secret_key=cfg["secret_key"],
         secure=cfg.get("secure", False),
+        region=cfg.get("region", _DEFAULT_S3_REGION),
     )
 
 
@@ -40,6 +44,12 @@ def get_s3_presign_client() -> Minio:
     be signed against ``storage.s3.public_endpoint`` instead — falls back
     to ``endpoint`` when unset, so existing single-endpoint deployments are
     unaffected.
+
+    ``region`` is pinned explicitly (not left for the SDK to auto-detect)
+    because auto-detection does a live bucket-location HTTP call against
+    the endpoint being signed for — and ``public_endpoint`` is reachable
+    from a browser, not necessarily from wherever this signing code runs,
+    so that lookup can't be relied on to succeed.
     """
     cfg = get_section("storage.s3")
     return Minio(
@@ -47,6 +57,7 @@ def get_s3_presign_client() -> Minio:
         access_key=cfg["access_key"],
         secret_key=cfg["secret_key"],
         secure=cfg.get("public_secure", cfg.get("secure", False)),
+        region=cfg.get("region", _DEFAULT_S3_REGION),
     )
 
 

--- a/Suspicious/Suspicious/common/tests/test_clients.py
+++ b/Suspicious/Suspicious/common/tests/test_clients.py
@@ -14,7 +14,8 @@ class GetS3ClientTest(SimpleTestCase):
             from common.clients import get_s3_client
             get_s3_client()
         minio_cls.assert_called_once_with(
-            endpoint="rustfs:9000", access_key="ak", secret_key="sk", secure=False
+            endpoint="rustfs:9000", access_key="ak", secret_key="sk", secure=False,
+            region="us-east-1",
         )
 
 
@@ -29,7 +30,8 @@ class GetS3PresignClientTest(SimpleTestCase):
             from common.clients import get_s3_presign_client
             get_s3_presign_client()
         minio_cls.assert_called_once_with(
-            endpoint="localhost:35002", access_key="ak", secret_key="sk", secure=False
+            endpoint="localhost:35002", access_key="ak", secret_key="sk", secure=False,
+            region="us-east-1",
         )
 
     def test_falls_back_to_internal_endpoint_when_unset(self):
@@ -42,8 +44,22 @@ class GetS3PresignClientTest(SimpleTestCase):
             from common.clients import get_s3_presign_client
             get_s3_presign_client()
         minio_cls.assert_called_once_with(
-            endpoint="rustfs:9000", access_key="ak", secret_key="sk", secure=False
+            endpoint="rustfs:9000", access_key="ak", secret_key="sk", secure=False,
+            region="us-east-1",
         )
+
+    def test_region_is_never_auto_detected_over_the_network(self):
+        """Regression guard: presign client must not need live connectivity
+        to public_endpoint just to construct a signature."""
+        section = {
+            "endpoint": "rustfs:9000", "public_endpoint": "unreachable-from-backend:9999",
+            "access_key": "ak", "secret_key": "sk", "secure": False,
+        }
+        with mock.patch("common.clients.get_section", return_value=section), \
+             mock.patch("common.clients.Minio") as minio_cls:
+            from common.clients import get_s3_presign_client
+            get_s3_presign_client()
+        self.assertEqual(minio_cls.call_args.kwargs["region"], "us-east-1")
 
 
 class GetChromaClientTest(SimpleTestCase):

--- a/Suspicious/Suspicious/common/tests/test_clients.py
+++ b/Suspicious/Suspicious/common/tests/test_clients.py
@@ -18,6 +18,34 @@ class GetS3ClientTest(SimpleTestCase):
         )
 
 
+class GetS3PresignClientTest(SimpleTestCase):
+    def test_uses_public_endpoint_when_set(self):
+        section = {
+            "endpoint": "rustfs:9000", "public_endpoint": "localhost:35002",
+            "access_key": "ak", "secret_key": "sk", "secure": False,
+        }
+        with mock.patch("common.clients.get_section", return_value=section), \
+             mock.patch("common.clients.Minio") as minio_cls:
+            from common.clients import get_s3_presign_client
+            get_s3_presign_client()
+        minio_cls.assert_called_once_with(
+            endpoint="localhost:35002", access_key="ak", secret_key="sk", secure=False
+        )
+
+    def test_falls_back_to_internal_endpoint_when_unset(self):
+        section = {
+            "endpoint": "rustfs:9000", "access_key": "ak",
+            "secret_key": "sk", "secure": False,
+        }
+        with mock.patch("common.clients.get_section", return_value=section), \
+             mock.patch("common.clients.Minio") as minio_cls:
+            from common.clients import get_s3_presign_client
+            get_s3_presign_client()
+        minio_cls.assert_called_once_with(
+            endpoint="rustfs:9000", access_key="ak", secret_key="sk", secure=False
+        )
+
+
 class GetChromaClientTest(SimpleTestCase):
     def test_builds_http_client_from_section(self):
         section = {"host": "chromadb", "port": 8000}

--- a/Suspicious/Suspicious/profiles/profiles_utils/avatar_storage.py
+++ b/Suspicious/Suspicious/profiles/profiles_utils/avatar_storage.py
@@ -14,7 +14,7 @@ from datetime import timedelta
 
 from PIL import Image, UnidentifiedImageError
 
-from common.clients import get_s3_client
+from common.clients import get_s3_client, get_s3_presign_client
 from settings.config import get_section
 
 logger = logging.getLogger(__name__)
@@ -98,7 +98,7 @@ def delete_avatar(key: str) -> None:
 def presigned_avatar_url(key: str) -> str | None:
     """Presigned GET URL for a stored avatar, or None on any failure."""
     try:
-        client = get_s3_client()
+        client = get_s3_presign_client()
         return client.presigned_get_object(
             _avatar_bucket_name(), key, expires=AVATAR_URL_EXPIRES
         )

--- a/Suspicious/Suspicious/profiles/profiles_utils/test_avatar_storage.py
+++ b/Suspicious/Suspicious/profiles/profiles_utils/test_avatar_storage.py
@@ -141,7 +141,7 @@ class PresignedAvatarUrlTest(SimpleTestCase):
         fake_client = mock.MagicMock()
         fake_client.presigned_get_object.return_value = "https://rustfs/signed"
         with mock.patch(
-            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            "profiles.profiles_utils.avatar_storage.get_s3_presign_client",
             return_value=fake_client,
         ):
             url = presigned_avatar_url("avatars/1/abc.jpg")
@@ -151,7 +151,7 @@ class PresignedAvatarUrlTest(SimpleTestCase):
         fake_client = mock.MagicMock()
         fake_client.presigned_get_object.side_effect = Exception("boom")
         with mock.patch(
-            "profiles.profiles_utils.avatar_storage.get_s3_client",
+            "profiles.profiles_utils.avatar_storage.get_s3_presign_client",
             return_value=fake_client,
         ):
             url = presigned_avatar_url("avatars/1/abc.jpg")

--- a/deployment/compose_databases.yaml
+++ b/deployment/compose_databases.yaml
@@ -107,6 +107,7 @@ services:
       - "9000"
     ports:
       - "127.0.0.1:${MINIO_PORT:-35000}:9001"
+      - "127.0.0.1:${MINIO_API_PORT:-35002}:9000"
     environment:
       RUSTFS_ACCESS_KEY:    ${MINIO_ROOT_USER}
       RUSTFS_SECRET_KEY:    ${MINIO_ROOT_PASSWORD}

--- a/docs/getting-started/examples/Suspicious-settings.example.json
+++ b/docs/getting-started/examples/Suspicious-settings.example.json
@@ -48,7 +48,7 @@
         "backend": "local",
         "s3": {
             "endpoint": "rustfs:9000",
-            "public_endpoint": "localhost:9000",
+            "public_endpoint": "localhost:35002",
             "access_key": "minio",
             "secret_key": "meridian_dev_minio_pw",
             "secure": false,

--- a/docs/getting-started/examples/Suspicious-settings.example.json
+++ b/docs/getting-started/examples/Suspicious-settings.example.json
@@ -48,6 +48,7 @@
         "backend": "local",
         "s3": {
             "endpoint": "rustfs:9000",
+            "public_endpoint": "localhost:9000",
             "access_key": "minio",
             "secret_key": "meridian_dev_minio_pw",
             "secure": false,

--- a/suspicious-ui/src/features/investigation/api.ts
+++ b/suspicious-ui/src/features/investigation/api.ts
@@ -69,7 +69,6 @@ type InvestigationAnalyzerReport = {
   categories: string[];
   report_summary?: unknown;
   report_taxonomy?: unknown;
-  report_full?: unknown;
   target: InvestigationAnalyzerTarget | null;
   created_at?: string;
 };
@@ -260,7 +259,6 @@ function normalizeAnalyzerReport(input: unknown): InvestigationAnalyzerReport {
     categories: asStringArray(report.categories),
     report_summary: report.report_summary,
     report_taxonomy: report.report_taxonomy,
-    report_full: report.report_full,
     target: normalizeAnalyzerTarget(report.target),
     created_at: typeof report.created_at === "string" ? report.created_at : undefined,
   };

--- a/traefik/dynamic/tls.yaml
+++ b/traefik/dynamic/tls.yaml
@@ -11,6 +11,13 @@
 #   https://<DOMAIN>/media/*     → Django media files on suspicious:9020
 #   https://<DOMAIN>/oidc/*      → Django OIDC views on suspicious:9020
 #   https://<DOMAIN>/docs/*      → Django API docs (drf-spectacular) on suspicious:9020
+#   https://<DOMAIN>/<bucket>/*  → RustFS/MinIO S3 API on rustfs:9000 (presigned
+#                                   GETs — avatar photos, mail attachments).
+#                                   Same-origin so the img-src 'self' CSP below
+#                                   allows them; keep the bucket-name list in the
+#                                   suspicious-storage router in sync with
+#                                   storage.s3.{avatars_bucket,media_bucket,
+#                                   feeder_bucket} in settings.
 #   https://<DOMAIN>/*           → Nginx SPA (suspicious_ui:80) — catch-all
 #
 # The SPA router has a lower priority than the API router so path-prefix
@@ -156,6 +163,26 @@ http:
         - forward-real-ip
       tls: {}
 
+    # ── Storage router (RustFS/MinIO) — presigned S3 GETs ────────────────
+    # Presigned URLs are signed with endpoint=DOMAIN so they stay same-origin
+    # (storage.s3.public_endpoint / public_secure in settings) — the CSP
+    # img-src below is 'self' only, a foreign origin would just fail to
+    # load with no visible error. S3 path-style URLs put the bucket name
+    # first in the path, so no prefix stripping needed; the object key
+    # (path beyond the bucket) and query-string signature pass through as-is.
+    suspicious-storage:
+      entryPoints:
+        - websecure
+      rule: >-
+        PathPrefix(`/suspicious-avatars`)
+        || PathPrefix(`/suspicious-media`)
+        || PathPrefix(`/suspicious-feeder`)
+      priority: 20
+      service: rustfs-service
+      middlewares:
+        - security-headers
+      tls: {}
+
     # ── SPA router (Nginx) — catch-all ───────────────────────────────────
     # Handles everything else: /, /login, /submissions, /dashboard, etc.
     # React Router handles client-side navigation; Nginx returns index.html
@@ -189,6 +216,16 @@ http:
         servers:
           - url: "http://suspicious_ui:80"
         passHostHeader: false
+
+    # RustFS/MinIO — S3 SigV4 signs the "host" header (X-Amz-SignedHeaders),
+    # so whatever Host the browser sent when the URL was signed (DOMAIN) MUST
+    # reach rustfs unchanged, or signature verification fails. passHostHeader
+    # true is required here — the opposite of the other two services above.
+    rustfs-service:
+      loadBalancer:
+        servers:
+          - url: "http://rustfs:9000"
+        passHostHeader: true
 
 # ── TLS ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two related fixes from the same debugging session, bundled since they
landed together.

**Avatar upload / presigned S3 URLs** (0520f67, 76be206, 8a8d610, dfebff8)
- Presigned URLs (avatar photos, mail attachments) were signed against
  storage.s3.endpoint, a Docker-internal host the browser can't
  resolve. Added storage.s3.public_endpoint (falls back to endpoint,
  no-op for existing deployments).
- minio-py auto-detects the signing region via a live network call to
  whatever endpoint it's signing for -- broke as soon as
  public_endpoint pointed somewhere the backend itself couldn't reach.
  Pinned region explicitly so signing needs no round-trip.
- Behind Traefik, img-src 'self' CSP silently drops any image from a
  foreign origin (no console error). Added a suspicious-storage
  Traefik router so S3 GETs stay same-origin instead of widening CSP.
- Docs: clarified public_endpoint must match the browser's actual
  origin (CSP 'self' resolves against the address bar, not
  DOMAIN_CORP).

**Investigations page performance** (c552e7f)
- Case detail was taking 10+s / 1MB+ on cases with many analyzer
  reports: InvestigationAnalyzerReportSerializer embedded each
  report's raw report_full blob unconditionally (VirusTotal reports
  alone ran 300-700KB each). Grepped the frontend -- that field is
  never rendered anywhere. Removed it.
- Investigations list queryset had an unconditional .distinct() that
  can't ever deduplicate anything (every joined relation is a forward
  FK/O2O from Case, never reverse/M2M -- no fan-out possible).
  Measured ~1.6s wasted per page on a 41k-row table forcing MySQL to
  sort/dedupe an already-duplicate-free result.

## Test plan

- [x] Backend: python manage.py test -- 575 tests pass
- [x] Frontend: tsc --noEmit -- clean
- [x] Avatar upload verified end-to-end against a live stack (upload,
      presigned URL, browser fetch, same-origin through Traefik)
- [x] Investigations payload verified against real prod data (86
      analyzer reports on one case): confirmed report_full was
      over 1MB of the 1.09MB response, confirmed via SHOW INDEX and
      CaptureQueriesContext that .distinct() added ~1.6s with no
      behavioral effect