### PR TITLE
fix(mail-header-analyzer): recover flattened headers, defanged domains

### DIFF
--- a/Analyzers/MailHeaderAnalyzer/mail_header_analysis.py
+++ b/Analyzers/MailHeaderAnalyzer/mail_header_analysis.py
@@ -6,16 +6,42 @@ from email.utils import parseaddr
 
 _AUTH_RESULT_RE = re.compile(r'\b(spf|dkim|dmarc)\s*=\s*(\w+)', re.IGNORECASE)
 _EMBEDDED_ADDRESS_RE = re.compile(r'[\w.+-]+@[\w.-]+\.\w+')
+_HEADER_BOUNDARY_RE = re.compile(r' (?=[A-Za-z][\w-]*:(?:\s|$))')
+_DEFANGED_DOT_RE = re.compile(r'\[\.\]|\(\.\)')
+
+
+def _reflow_flattened_headers(header_text: str) -> str:
+    """Recover header boundaries when a paste tool (Outlook's "Internet
+    headers" popup is the classic offender) strips the real newlines and
+    hands back one long line, e.g. "...Transport; Wed, 22 Jul 2026
+    18:26:54 +0200 Received: from ...". Without this, message_from_string
+    reads the whole blob as the value of the very first header and every
+    later header (Authentication-Results, From, Reply-To...) silently
+    disappears.
+    ponytail: heuristic split on " Name:" boundaries, only when the block
+    looks flattened (near-zero real newlines) so a normal multi-line paste
+    is left untouched; upgrade to a real unfolding parser if this
+    misfires on some header's free-text value.
+    """
+    if header_text.count("\n") > 2:
+        return header_text
+    return _HEADER_BOUNDARY_RE.sub("\n", header_text)
 
 
 def parse_headers(header_text: str):
     """Parse a raw header block into an email.message.Message."""
-    return message_from_string(header_text or "")
+    return message_from_string(_reflow_flattened_headers(header_text or ""))
 
 
 def get_domain(address: str) -> str:
-    """Lowercased domain from an email address/header value, "" if unparseable."""
-    _, addr = parseaddr(address or "")
+    """Lowercased domain from an email address/header value, "" if unparseable.
+
+    ponytail: undoes only the "[.]"/"(.)"-style dot defanging analysts use
+    when sharing IOCs (a bracketed dot otherwise reads to parseaddr as an
+    RFC 5322 domain-literal and fails the whole address); add more patterns
+    (e.g. "[at]") if a defanging convention shows up that this misses.
+    """
+    _, addr = parseaddr(_DEFANGED_DOT_RE.sub(".", address or ""))
     if "@" not in addr:
         return ""
     return addr.rsplit("@", 1)[1].lower()

--- a/Analyzers/MailHeaderAnalyzer/tests/test_mail_header_analysis.py
+++ b/Analyzers/MailHeaderAnalyzer/tests/test_mail_header_analysis.py
@@ -130,6 +130,30 @@ def test_analyze_end_to_end():
     assert {"SPF", "DKIM", "DMARC", "ReplyToMatch", "ReturnPathMatch", "DisplayNameSpoofing"} == predicates
 
 
+def test_analyze_recovers_flattened_headers_with_no_real_linebreaks():
+    """Outlook's "Internet headers" popup, copy-pasted, commonly hands back
+    one long line instead of newline-separated headers. Without reflowing,
+    message_from_string reads the whole blob as one header's value and
+    every later header vanishes."""
+    flattened = (
+        "Received: from a.example (1.2.3.4) by b.example; Wed, 22 Jul 2026 18:26:54 +0200 "
+        "Authentication-Results: mx.example.com; spf=pass; dkim=pass; dmarc=pass "
+        "From: Attacker <attacker@evil.com> "
+        "Reply-To: attacker@evil.com"
+    )
+    report = mha.analyze(flattened)
+    assert report["auth_results"] == {"spf": "pass", "dkim": "pass", "dmarc": "pass"}
+    assert report["reply_to"]["from_domain"] == "evil.com"
+
+
+def test_get_domain_undoes_bracket_defanged_dots():
+    """CERT analysts routinely defang IOCs ("evil[.]com") before sharing a
+    header dump; parseaddr reads "[.]" as an RFC 5322 domain-literal and
+    fails the whole address, so domain extraction must undo it first."""
+    assert mha.get_domain("attacker@evil[.]com") == "evil.com"
+    assert mha.get_domain("Attacker <attacker@evil[.]com>") == "evil.com"
+
+
 def test_analyze_message_works_on_a_full_eml_not_just_bare_headers():
     """The .eml data-type entry point parses a full message (headers + body)
     via email.message_from_bytes — analyze_message must give the same result


### PR DESCRIPTION
## Summary
- Header blocks pasted without real newlines (e.g. Outlook's "Internet headers" popup) collapsed everything after the first header, silently zeroing out SPF/DKIM/DMARC and reply-to/return-path checks. `parse_headers` now reflows a flattened block before parsing.
- Bracket-defanged domains (`evil[.]com`), the standard IOC-sharing convention, made `parseaddr` fail the whole address for the same reason (it reads `[.]` as an RFC 5322 domain-literal). `get_domain` now undoes that defanging first.

## Test plan
- [x] Added regression tests for both cases (`test_analyze_recovers_flattened_headers_with_no_real_linebreaks`, `test_get_domain_undoes_bracket_defanged_dots`)
- [x] All 16 tests in `Analyzers/MailHeaderAnalyzer/tests/test_mail_header_analysis.py` pass
- [x] Verified against a real defanged/flattened Thales header sample: SPF/DKIM/DMARC correctly resolve to `pass`, Return-Path now correctly matches From domain