### PR TITLE
fix(scoring): stop AI mail analyzer report double-counting in file score

### DIFF
--- a/Suspicious/Suspicious/score_process/scoring/cortex_analyzers/reports.py
+++ b/Suspicious/Suspicious/score_process/scoring/cortex_analyzers/reports.py
@@ -184,3 +184,25 @@ class CortexAnalyzerReports:
         )
 
         return AnalyzerReport.objects.filter(id__in=latest_id_subquery)
+
+    @staticmethod
+    def exclude_ai_analyzer(reports):
+        """Drop the AI mail classifier's own report from a per-artifact
+        report list before weighting.
+
+        AI_Mail_Analyzer attaches its report to the mail archive's `file`
+        (see cortex_and_job_management.manage_ai_jobs), and collect.py
+        already surfaces that same score/confidence separately as the
+        dedicated `ai` override signal (built from case.score_ai/
+        confidence_ai). Leaving it inside this generic per-file weighted
+        blend double-counts it — inflating base_conf enough to tie
+        ai.confidence, which silences score_case()'s ai-override branch on
+        a tie and lets the case fall back to the (possibly neutral) base
+        score instead of the AI's actual verdict.
+        """
+        from cortex_job.cortex_utils.cortex_and_job_management import _get_cortex_config
+
+        ai_name = _get_cortex_config().get("analyzers", {}).get("ai")
+        if not ai_name:
+            return list(reports)
+        return [r for r in reports if r.analyzer.name != ai_name]

--- a/Suspicious/Suspicious/score_process/scoring/processing.py
+++ b/Suspicious/Suspicious/score_process/scoring/processing.py
@@ -277,9 +277,13 @@ def _process_file_ioc_base(
             reports, analyzers_reports_file, str(file_ioc.file_path.name), case_id
         )
 
+        scoring_reports_file = CortexAnalyzerReports.exclude_ai_analyzer(analyzers_reports_file)
+        if not scoring_reports_file:
+            return failure
+
         try:
             file_score, file_confidence, file_weight = compute_weighted_scores(
-                analyzers_reports_file, "file"
+                scoring_reports_file, "file"
             )
         except ValueError:
             update_cases_logger.warning("Zero analyzer weight for file %r — defaulting to 0.", file_ioc)

--- a/Suspicious/Suspicious/score_process/tests/test_collect.py
+++ b/Suspicious/Suspicious/score_process/tests/test_collect.py
@@ -1,9 +1,13 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.utils import timezone
 
-from case_handler.models import Case, CaseHasNonFileIocs
+from case_handler.models import Case, CaseHasFileOrMail, CaseHasNonFileIocs, Result
 from cortex_job.models import Analyzer, AnalyzerReport
+from file_process.models import File
+from hash_process.models import Hash
 from ip_process.models import IP
+from mail_feeder.models import Mail, MailArchive
 from score_process.scoring.collect import collect_signals
 from score_process.scoring.engine import Signal
 
@@ -56,3 +60,53 @@ class CollectSignalsTest(TestCase):
         )
         _, ai, _, _ = collect_signals(case)
         self.assertEqual(ai.confidence, 100)
+
+    def test_ai_report_on_archive_file_not_double_counted_as_generic_signal(self):
+        """Regression (prod case 61682): AI_Mail_Analyzer attaches its own
+        AnalyzerReport to the mail archive's `file` (cortex_and_job_management.py
+        manage_ai_jobs), which is the *same* value collect_signals already
+        surfaces separately via case.score_ai/confidence_ai as `ai`. Without
+        excluding it, that one report also gets pulled into the generic
+        per-file weighted signal, inflating base_conf to tie ai.confidence —
+        which silences the AI override in score_case() on ties and lets a
+        low-confidence neutral signal elsewhere decide the case instead.
+        """
+        from settings.config import get_section
+
+        mail = Mail.objects.create(
+            subject="s", reportedBy="r", date=timezone.now(), to="t", mail_id="m-ai-dup",
+        )
+        archive_file = File.objects.create(
+            linked_hash=Hash.objects.create(value="dup-archive-hash"), tmp_path="x.eml",
+        )
+        MailArchive.objects.create(mail=mail, archive=archive_file)
+
+        ai_name = get_section("integrations.cortex").get("analyzers", {}).get("ai")
+        ai_analyzer = Analyzer.objects.create(
+            analyzer_cortex_id="ai-dup-1", name=ai_name, weight=1.0,
+        )
+        AnalyzerReport.objects.create(
+            cortex_job_id="job-ai-dup", type="file", status="Success", analyzer=ai_analyzer,
+            file=archive_file, level="safe", confidence=100, score=0,
+            report_summary={}, report_full={}, report_taxonomy={},
+        )
+
+        case = Case.objects.create(
+            description="", reporter=self.user, score_ai=0, confidence_ai=100,
+            results_ai=Result.SAFE, category_ai="Internal",
+        )
+        fm = CaseHasFileOrMail.objects.create(case=case, mail=mail)
+        case.fileOrMail = fm
+        case.save(update_fields=["fileOrMail"])
+
+        signals, ai, _, ai_missing = collect_signals(case)
+
+        self.assertIsNotNone(ai)
+        self.assertEqual(ai.score, 0)
+        self.assertEqual(ai.confidence, 100)
+        self.assertFalse(ai_missing)
+        self.assertEqual(
+            signals, [],
+            "AI's own archive-file report leaked into the generic per-file "
+            "signal list, double-counting it alongside the dedicated `ai` signal.",
+        )


### PR DESCRIPTION
## Summary
- `AI_Mail_Analyzer` attaches its own `AnalyzerReport` to the mail archive's `file` (`cortex_and_job_management.manage_ai_jobs`) — the same value `collect.py` already surfaces separately as the dedicated `ai` override signal via `case.score_ai`/`confidence_ai`.
- Leaving it inside the generic per-file weighted blend (`_process_file_ioc_base` → `compute_weighted_scores`) double-counted it, inflating `base_conf` enough to tie `ai.confidence` — which silences `score_case()`'s ai-override branch (`ai.confidence > base_conf`, strict) on a tie, letting the case fall back to whatever the non-AI signals computed instead of the AI's actual verdict.
- Confirmed on prod case 61682: AI reported `Safe`/`score=0`/`confidence=100`, but the archive file's *own* weighted signal was that same AI report — tying `base_conf` to `ai.confidence` exactly. A second, low-confidence (50) neutral `FileInfo` attachment report then pushed `base_score` to the `NEUTRAL` sentinel (5) via the pessimistic `worst()` term, and `NEUTRAL` forces `Result.INCONCLUSIVE` regardless of what AI said — discarding a 100%-confident `Safe` verdict.
- `_process_file_ioc_base` now excludes the AI analyzer (via the same `integrations.cortex.analyzers.ai` config key `manage_ai_jobs` already uses) from the file-report weighting, so it only ever flows through the dedicated `ai` override path.

## Test plan
- [x] Added regression test `test_ai_report_on_archive_file_not_double_counted_as_generic_signal` in `score_process/tests/test_collect.py` — fails before the fix (reproduces double-count), passes after.
- [x] `score_process` + `cortex_job` suites: 118/118 pass.
- [x] Full backend suite: 584/584 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)