### PR TITLE
feat(investigation): add Redo analysis action

### DIFF
--- a/Suspicious/Suspicious/api/tests/test_investigation_redo_analysis.py
+++ b/Suspicious/Suspicious/api/tests/test_investigation_redo_analysis.py
@@ -1,0 +1,118 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from case_handler.lifecycle import LifecycleState
+from case_handler.models import Case, CaseHasNonFileIocs, Result
+from cortex_job.models import Analyzer, AnalyzerReport
+from url_process.models import URL
+
+User = get_user_model()
+
+
+def _make_user(username, *, groups=()):
+    user = User.objects.create_user(username=username, password="pw-12345")
+    for name in groups:
+        group, _ = Group.objects.get_or_create(name=name)
+        user.groups.add(group)
+    return user
+
+
+class InvestigationRedoAnalysisTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.reporter = _make_user("redo_reporter")
+        self.analyst = _make_user("redo_analyst", groups=["CERT"])
+        self.url = URL.objects.create(address="http://example.com")
+
+    def _make_case(self, lifecycle_state):
+        # ponytail: CaseHasNonFileIocs.case is a required FK (see
+        # case_handler/migrations/0001_initial.py), so the case must exist
+        # before the iocs row, then get linked back — matches the pattern
+        # every other test in this repo uses (e.g. cortex_job/tests/
+        # test_case_targets.py), not create(nonFileIocs=...) up front.
+        case = Case.objects.create(
+            reporter=self.reporter, description="", lifecycle_state=lifecycle_state,
+        )
+        iocs = CaseHasNonFileIocs.objects.create(case=case, url=self.url)
+        case.nonFileIocs = iocs
+        case.save()
+        return case
+
+    def _redo_url(self, case):
+        return reverse("investigation-redo-analysis", kwargs={"case_id": case.id})
+
+    def test_reporter_forbidden(self):
+        case = self._make_case(LifecycleState.FINALIZED)
+        self.client.force_authenticate(self.reporter)
+        resp = self.client.post(self._redo_url(case))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_non_terminal_case_returns_409(self):
+        case = self._make_case(LifecycleState.ANALYZING)
+        self.client.force_authenticate(self.analyst)
+        resp = self.client.post(self._redo_url(case))
+        self.assertEqual(resp.status_code, 409)
+        case.refresh_from_db()
+        self.assertEqual(case.lifecycle_state, LifecycleState.ANALYZING)
+
+    @patch("api.views.investigations.dispatch_case_analysis")
+    def test_finalized_case_dispatches_and_resets(self, mock_dispatch):
+        case = self._make_case(LifecycleState.FINALIZED)
+        case.results = Result.DANGEROUS
+        case.score = 9
+        case.final_score = 9
+        case.description = "old verdict"
+        case.save()
+
+        self.client.force_authenticate(self.analyst)
+        resp = self.client.post(self._redo_url(case))
+
+        self.assertEqual(resp.status_code, 202)
+        self.assertEqual(resp.data["dispatched"], 1)
+
+        mock_dispatch.delay.assert_called_once()
+        called_case_id, called_intents = mock_dispatch.delay.call_args[0]
+        self.assertEqual(called_case_id, case.id)
+        self.assertEqual(called_intents, [("url_process.url", self.url.id, "url")])
+
+        case.refresh_from_db()
+        self.assertEqual(case.lifecycle_state, LifecycleState.ANALYZING)
+        self.assertEqual(case.results, Result.INCONCLUSIVE)
+        self.assertEqual(case.score, 0)
+        self.assertEqual(case.final_score, 0)
+        self.assertEqual(case.description, "")
+
+    @patch("api.views.investigations.dispatch_case_analysis")
+    def test_contested_case_can_redo(self, mock_dispatch):
+        case = self._make_case(LifecycleState.CONTESTED)
+        self.client.force_authenticate(self.analyst)
+        resp = self.client.post(self._redo_url(case))
+        self.assertEqual(resp.status_code, 202)
+        case.refresh_from_db()
+        self.assertEqual(case.lifecycle_state, LifecycleState.ANALYZING)
+
+    def test_case_with_no_targets_returns_400(self):
+        case = Case.objects.create(
+            reporter=self.reporter, description="", lifecycle_state=LifecycleState.FINALIZED,
+        )
+        self.client.force_authenticate(self.analyst)
+        resp = self.client.post(self._redo_url(case))
+        self.assertEqual(resp.status_code, 400)
+
+    @patch("api.views.investigations.dispatch_case_analysis")
+    def test_old_analyzer_reports_are_not_deleted(self, mock_dispatch):
+        case = self._make_case(LifecycleState.FINALIZED)
+        analyzer = Analyzer.objects.create(name="YARA", analyzer_cortex_id="yara-1")
+        AnalyzerReport.objects.create(
+            cortex_job_id="job-1", type="url", status="Success", analyzer=analyzer,
+            url=self.url, level="info", confidence=1, score=1,
+            report_summary={}, report_taxonomy={}, report_full={},
+        )
+        self.client.force_authenticate(self.analyst)
+        self.client.post(self._redo_url(case))
+        self.assertEqual(AnalyzerReport.objects.count(), 1)

--- a/Suspicious/Suspicious/api/urls.py
+++ b/Suspicious/Suspicious/api/urls.py
@@ -29,6 +29,7 @@ from api.views.investigations import (
     InvestigationDetailsView,
     InvestigationGlobalEditView,
     InvestigationListView,
+    InvestigationRedoAnalysisView,
 )
 from api.views.profile import (
     ProfileView,
@@ -125,6 +126,8 @@ urlpatterns = [
     path("investigations/", InvestigationListView.as_view(), name="investigation-list"),
     path("investigations/<int:case_id>/", InvestigationDetailsView.as_view(), name="investigation-details"),
     path("investigations/<int:case_id>/edit-global/", InvestigationGlobalEditView.as_view(), name="investigation-edit-global"),
+    path("investigations/<int:case_id>/redo-analysis/",
+         InvestigationRedoAnalysisView.as_view(), name="investigation-redo-analysis"),
 
     path("submit/config/", SubmitConfigView.as_view(), name="submit-config"),
     path("submit/url/", SubmitUrlView.as_view(), name="submit-url"),

--- a/Suspicious/Suspicious/api/views/investigations.py
+++ b/Suspicious/Suspicious/api/views/investigations.py
@@ -12,7 +12,7 @@ from rest_framework.views import APIView
 
 from case_handler.models import Case
 from cortex_job.models import AnalyzerReport
-from cortex_job.cortex_utils.case_targets import collect_case_targets
+from cortex_job.cortex_utils.case_targets import build_analyzer_report_filter, collect_case_targets
 from api.utils.investigation_pagination import InvestigationPagination
 from api.serializers.investigations import (
     API_RESULT_TO_INTERNAL,
@@ -144,18 +144,7 @@ class InvestigationAccessMixin:
         if not targets:
             return AnalyzerReport.objects.none()
 
-        field_by_type = {
-            "file": "file_id", "mail_body": "mail_body_id", "mail_header": "mail_header_id",
-            "url": "url_id", "ip": "ip_id", "hash": "hash_id", "domain": "domain_id",
-            "mail": "mail_id",
-        }
-        ids_by_field: dict[str, list[int]] = {}
-        for instance, data_type in targets:
-            ids_by_field.setdefault(field_by_type[data_type], []).append(instance.pk)
-
-        query = Q()
-        for field, ids in ids_by_field.items():
-            query |= Q(**{f"{field}__in": ids})
+        query = build_analyzer_report_filter(targets)
 
         # No .distinct() needed: every filter above is a plain equality/IN on
         # AnalyzerReport's own FK columns (never a reverse/M2M traversal), and

--- a/Suspicious/Suspicious/api/views/investigations.py
+++ b/Suspicious/Suspicious/api/views/investigations.py
@@ -10,9 +10,11 @@ from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from case_handler.models import Case
+from case_handler.lifecycle import IllegalTransition, LifecycleState, transition
+from case_handler.models import Case, Result
 from cortex_job.models import AnalyzerReport
 from cortex_job.cortex_utils.case_targets import build_analyzer_report_filter, collect_case_targets
+from tasp.tasks import dispatch_case_analysis
 from api.utils.investigation_pagination import InvestigationPagination
 from api.serializers.investigations import (
     API_RESULT_TO_INTERNAL,
@@ -375,3 +377,58 @@ class InvestigationGlobalEditView(InvestigationAccessMixin, APIView):
             },
         )
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@extend_schema(
+    tags=["Investigations"],
+    responses={
+        202: OpenApiResponse(description="Analysis redispatched."),
+        400: OpenApiResponse(description="No analyzable artifacts on this case."),
+        403: OpenApiResponse(description="Not authorized."),
+        404: OpenApiResponse(description="Investigation not found."),
+        409: OpenApiResponse(description="Case is still being analyzed."),
+    },
+)
+class InvestigationRedoAnalysisView(InvestigationAccessMixin, APIView):
+    permission_classes = [IsAuthenticated, IsInvestigator]
+
+    def post(self, request, case_id: int):
+        case = self.get_case_or_404(case_id)
+
+        if case.lifecycle_state not in (LifecycleState.FINALIZED, LifecycleState.CONTESTED):
+            return Response(
+                {"detail": "Case is still being analyzed."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        targets = collect_case_targets(case)
+        if not targets:
+            return Response(
+                {"detail": "No analyzable artifacts on this case."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            transition(case, LifecycleState.ANALYZING)
+        except IllegalTransition:
+            return Response(
+                {"detail": "Case is still being analyzed."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        case.results = Result.INCONCLUSIVE
+        case.score = 0
+        case.final_score = 0
+        case.description = ""
+        case.save(update_fields=["results", "score", "final_score", "description"])
+
+        intents = [
+            (f"{instance._meta.app_label}.{instance._meta.model_name}", instance.pk, data_type)
+            for instance, data_type in targets
+        ]
+        dispatch_case_analysis.delay(case.id, intents)
+
+        return Response(
+            {"status": "queued", "dispatched": len(intents)},
+            status=status.HTTP_202_ACCEPTED,
+        )

--- a/Suspicious/Suspicious/api/views/investigations.py
+++ b/Suspicious/Suspicious/api/views/investigations.py
@@ -12,6 +12,7 @@ from rest_framework.views import APIView
 
 from case_handler.models import Case
 from cortex_job.models import AnalyzerReport
+from cortex_job.cortex_utils.case_targets import collect_case_targets
 from api.utils.investigation_pagination import InvestigationPagination
 from api.serializers.investigations import (
     API_RESULT_TO_INTERNAL,
@@ -139,91 +140,35 @@ class InvestigationAccessMixin:
             raise NotFound("Investigation not found.") from exc
 
     def get_analyzer_reports_queryset(self, obj: Case):
-        query = Q()
-
-        file_or_mail = getattr(obj, "fileOrMail", None)
-        non_file_iocs = getattr(obj, "nonFileIocs", None)
-
-        if obj.fileOrMail_id and file_or_mail:
-            if file_or_mail.file_id:
-                query |= Q(file_id=file_or_mail.file_id)
-
-            if file_or_mail.mail_id and getattr(file_or_mail, "mail", None):
-                mail = file_or_mail.mail
-
-                if mail.mail_body_id:
-                    query |= Q(mail_body_id=mail.mail_body_id)
-
-                if mail.mail_header_id:
-                    query |= Q(mail_header_id=mail.mail_header_id)
-
-                attachment_file_ids = list(
-                    mail.mail_attachments.exclude(file_id__isnull=True)
-                    .values_list("file_id", flat=True)
-                )
-                if attachment_file_ids:
-                    query |= Q(file_id__in=attachment_file_ids)
-
-                url_ids = []
-                ip_ids = []
-                hash_ids = []
-                domain_ids = []
-                mail_address_ids = []
-
-                for artifact in mail.mail_artifacts.select_related(
-                    "artifactIsUrl",
-                    "artifactIsIp",
-                    "artifactIsHash",
-                    "artifactIsDomain",
-                    "artifactIsMailAddress",
-                ):
-                    if artifact.artifactIsUrl_id and artifact.artifactIsUrl and artifact.artifactIsUrl.url_id:
-                        url_ids.append(artifact.artifactIsUrl.url_id)
-
-                    if artifact.artifactIsIp_id and artifact.artifactIsIp and artifact.artifactIsIp.ip_id:
-                        ip_ids.append(artifact.artifactIsIp.ip_id)
-
-                    if artifact.artifactIsHash_id and artifact.artifactIsHash and artifact.artifactIsHash.hash_id:
-                        hash_ids.append(artifact.artifactIsHash.hash_id)
-
-                    if artifact.artifactIsDomain_id and artifact.artifactIsDomain and artifact.artifactIsDomain.domain_id:
-                        domain_ids.append(artifact.artifactIsDomain.domain_id)
-
-                    if (
-                        artifact.artifactIsMailAddress_id
-                        and artifact.artifactIsMailAddress
-                        and artifact.artifactIsMailAddress.mail_address_id
-                    ):
-                        mail_address_ids.append(artifact.artifactIsMailAddress.mail_address_id)
-
-                if url_ids:
-                    query |= Q(url_id__in=url_ids)
-                if ip_ids:
-                    query |= Q(ip_id__in=ip_ids)
-                if hash_ids:
-                    query |= Q(hash_id__in=hash_ids)
-                if domain_ids:
-                    query |= Q(domain_id__in=domain_ids)
-                if mail_address_ids:
-                    query |= Q(mail_id__in=mail_address_ids)
-
-        if obj.nonFileIocs_id and non_file_iocs:
-            if non_file_iocs.url_id:
-                query |= Q(url_id=non_file_iocs.url_id)
-            if non_file_iocs.ip_id:
-                query |= Q(ip_id=non_file_iocs.ip_id)
-            if non_file_iocs.hash_id:
-                query |= Q(hash_id=non_file_iocs.hash_id)
-
-        if not query.children:
+        targets = collect_case_targets(obj)
+        if not targets:
             return AnalyzerReport.objects.none()
 
+        field_by_type = {
+            "file": "file_id", "mail_body": "mail_body_id", "mail_header": "mail_header_id",
+            "url": "url_id", "ip": "ip_id", "hash": "hash_id", "domain": "domain_id",
+            "mail": "mail_id",
+        }
+        ids_by_field: dict[str, list[int]] = {}
+        for instance, data_type in targets:
+            ids_by_field.setdefault(field_by_type[data_type], []).append(instance.pk)
+
+        query = Q()
+        for field, ids in ids_by_field.items():
+            query |= Q(**{f"{field}__in": ids})
+
+        # No .distinct() needed: every filter above is a plain equality/IN on
+        # AnalyzerReport's own FK columns (never a reverse/M2M traversal), and
+        # every select_related() relation is forward FK/O2O — this queryset
+        # structurally can't fan out into duplicate rows. distinct() was
+        # forcing MySQL to sort/dedupe the full 9-table-wide join with no
+        # LIMIT to cap it, and _dedup_analyzer_reports() below already
+        # de-dupes in Python regardless.
         qs = (
             AnalyzerReport.objects
             .filter(query)
             .select_related(*self.analyzer_report_select_related)
             .order_by("-creation_date", "-pk")
-            .distinct()
         )
         return _dedup_analyzer_reports(qs)
 

--- a/Suspicious/Suspicious/api/views/submissions.py
+++ b/Suspicious/Suspicious/api/views/submissions.py
@@ -23,7 +23,7 @@ from api.serializers.submissions import (
 )
 from case_handler.models import Case
 from cortex_job.models import AnalyzerReport
-from cortex_job.cortex_utils.case_targets import collect_case_targets
+from cortex_job.cortex_utils.case_targets import build_analyzer_report_filter, collect_case_targets
 from tasp.services.challenge import notify_and_record_challenge
 
 logger = logging.getLogger(__name__)
@@ -204,18 +204,7 @@ class SubmissionDetailsView(RetrieveAPIView):
         if not targets:
             return []
 
-        field_by_type = {
-            "file": "file_id", "mail_body": "mail_body_id", "mail_header": "mail_header_id",
-            "url": "url_id", "ip": "ip_id", "hash": "hash_id", "domain": "domain_id",
-            "mail": "mail_id",
-        }
-        ids_by_field: dict[str, list[int]] = {}
-        for instance, data_type in targets:
-            ids_by_field.setdefault(field_by_type[data_type], []).append(instance.pk)
-
-        filters = Q()
-        for field, ids in ids_by_field.items():
-            filters |= Q(**{f"{field}__in": ids})
+        filters = build_analyzer_report_filter(targets)
 
         # No .distinct() needed: every filter above is a plain equality/IN on
         # AnalyzerReport's own FK columns, and every select_related() relation

--- a/Suspicious/Suspicious/api/views/submissions.py
+++ b/Suspicious/Suspicious/api/views/submissions.py
@@ -23,6 +23,7 @@ from api.serializers.submissions import (
 )
 from case_handler.models import Case
 from cortex_job.models import AnalyzerReport
+from cortex_job.cortex_utils.case_targets import collect_case_targets
 from tasp.services.challenge import notify_and_record_challenge
 
 logger = logging.getLogger(__name__)
@@ -199,75 +200,27 @@ class SubmissionDetailsView(RetrieveAPIView):
         return obj
 
     def _get_analyzer_reports_queryset(self, obj: Case):
-        filters = Q()
-
-        linked_file_or_mail = getattr(obj, "fileOrMail", None)
-        linked_non_file_iocs = getattr(obj, "nonFileIocs", None)
-
-        if obj.fileOrMail_id and linked_file_or_mail is not None:
-            if linked_file_or_mail.file_id:
-                filters |= Q(file_id=linked_file_or_mail.file_id)
-
-            if linked_file_or_mail.mail_id and getattr(linked_file_or_mail, "mail", None):
-                mail = linked_file_or_mail.mail
-
-                if mail.mail_body_id:
-                    filters |= Q(mail_body_id=mail.mail_body_id)
-                if mail.mail_header_id:
-                    filters |= Q(mail_header_id=mail.mail_header_id)
-
-                attachment_file_ids = list(
-                    mail.mail_attachments.exclude(file_id__isnull=True)
-                    .values_list("file_id", flat=True)
-                )
-                if attachment_file_ids:
-                    filters |= Q(file_id__in=attachment_file_ids)
-
-                artifact_url_ids, artifact_ip_ids, artifact_hash_ids = [], [], []
-                artifact_domain_ids, artifact_mail_address_ids = [], []
-
-                for artifact in mail.mail_artifacts.select_related(
-                    "artifactIsUrl", "artifactIsUrl__url", "artifactIsIp", "artifactIsHash",
-                    "artifactIsDomain", "artifactIsMailAddress",
-                ):
-                    if artifact.artifactIsUrl_id and artifact.artifactIsUrl and artifact.artifactIsUrl.url_id:
-                        artifact_url_ids.append(artifact.artifactIsUrl.url_id)
-                        if getattr(artifact.artifactIsUrl.url, "analyzed_url_id", None):
-                            artifact_url_ids.append(artifact.artifactIsUrl.url.analyzed_url_id)
-                    if artifact.artifactIsIp_id and artifact.artifactIsIp and artifact.artifactIsIp.ip_id:
-                        artifact_ip_ids.append(artifact.artifactIsIp.ip_id)
-                    if artifact.artifactIsHash_id and artifact.artifactIsHash and artifact.artifactIsHash.hash_id:
-                        artifact_hash_ids.append(artifact.artifactIsHash.hash_id)
-                    if artifact.artifactIsDomain_id and artifact.artifactIsDomain and artifact.artifactIsDomain.domain_id:
-                        artifact_domain_ids.append(artifact.artifactIsDomain.domain_id)
-                    if (artifact.artifactIsMailAddress_id and artifact.artifactIsMailAddress
-                            and artifact.artifactIsMailAddress.mail_address_id):
-                        artifact_mail_address_ids.append(artifact.artifactIsMailAddress.mail_address_id)
-
-                if artifact_url_ids:
-                    filters |= Q(url_id__in=artifact_url_ids)
-                if artifact_ip_ids:
-                    filters |= Q(ip_id__in=artifact_ip_ids)
-                if artifact_hash_ids:
-                    filters |= Q(hash_id__in=artifact_hash_ids)
-                if artifact_domain_ids:
-                    filters |= Q(domain_id__in=artifact_domain_ids)
-                if artifact_mail_address_ids:
-                    filters |= Q(mail_id__in=artifact_mail_address_ids)
-
-        if obj.nonFileIocs_id and linked_non_file_iocs is not None:
-            if linked_non_file_iocs.url_id:
-                filters |= Q(url_id=linked_non_file_iocs.url_id)
-                if getattr(getattr(linked_non_file_iocs, "url", None), "analyzed_url_id", None):
-                    filters |= Q(url_id=linked_non_file_iocs.url.analyzed_url_id)
-            if linked_non_file_iocs.ip_id:
-                filters |= Q(ip_id=linked_non_file_iocs.ip_id)
-            if linked_non_file_iocs.hash_id:
-                filters |= Q(hash_id=linked_non_file_iocs.hash_id)
-
-        if not filters.children:
+        targets = collect_case_targets(obj)
+        if not targets:
             return []
 
+        field_by_type = {
+            "file": "file_id", "mail_body": "mail_body_id", "mail_header": "mail_header_id",
+            "url": "url_id", "ip": "ip_id", "hash": "hash_id", "domain": "domain_id",
+            "mail": "mail_id",
+        }
+        ids_by_field: dict[str, list[int]] = {}
+        for instance, data_type in targets:
+            ids_by_field.setdefault(field_by_type[data_type], []).append(instance.pk)
+
+        filters = Q()
+        for field, ids in ids_by_field.items():
+            filters |= Q(**{f"{field}__in": ids})
+
+        # No .distinct() needed: every filter above is a plain equality/IN on
+        # AnalyzerReport's own FK columns, and every select_related() relation
+        # is forward FK/O2O — structurally can't fan out into duplicate rows.
+        # _dedup_analyzer_reports() below already de-dupes in Python regardless.
         qs = (
             AnalyzerReport.objects.filter(filters)
             .select_related(
@@ -275,7 +228,6 @@ class SubmissionDetailsView(RetrieveAPIView):
                 "file", "ip", "mail_body", "mail_header",
             )
             .order_by("-creation_date", "-id")
-            .distinct()
         )
         return _dedup_analyzer_reports(qs)
 

--- a/Suspicious/Suspicious/case_handler/lifecycle.py
+++ b/Suspicious/Suspicious/case_handler/lifecycle.py
@@ -28,8 +28,10 @@ LEGAL_TRANSITIONS = {
                                LifecycleState.FINALIZED},
     LifecycleState.ANALYZING: {LifecycleState.SCORING},
     LifecycleState.SCORING:   {LifecycleState.FINALIZED},
-    LifecycleState.FINALIZED: {LifecycleState.CONTESTED},
-    LifecycleState.CONTESTED: {LifecycleState.FINALIZED},
+    # ANALYZING added on both terminal states for the redo-analysis feature:
+    # an investigator can send a finished case back for a fresh analysis run.
+    LifecycleState.FINALIZED: {LifecycleState.CONTESTED, LifecycleState.ANALYZING},
+    LifecycleState.CONTESTED: {LifecycleState.FINALIZED, LifecycleState.ANALYZING},
 }
 
 

--- a/Suspicious/Suspicious/case_handler/tests/test_lifecycle_redo_transition.py
+++ b/Suspicious/Suspicious/case_handler/tests/test_lifecycle_redo_transition.py
@@ -1,0 +1,37 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from case_handler.lifecycle import LifecycleState, transition
+from case_handler.models import Case
+
+User = get_user_model()
+
+
+class RedoLifecycleTransitionTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="lc_user", password="pw-12345")
+
+    def test_finalized_can_transition_to_analyzing(self):
+        case = Case.objects.create(
+            reporter=self.user, description="", lifecycle_state=LifecycleState.FINALIZED,
+        )
+        transition(case, LifecycleState.ANALYZING)
+        case.refresh_from_db()
+        self.assertEqual(case.lifecycle_state, LifecycleState.ANALYZING)
+
+    def test_contested_can_transition_to_analyzing(self):
+        case = Case.objects.create(
+            reporter=self.user, description="", lifecycle_state=LifecycleState.CONTESTED,
+        )
+        transition(case, LifecycleState.ANALYZING)
+        case.refresh_from_db()
+        self.assertEqual(case.lifecycle_state, LifecycleState.ANALYZING)
+
+    def test_finalized_to_contested_still_works(self):
+        """Guard against the new edge accidentally replacing the existing one."""
+        case = Case.objects.create(
+            reporter=self.user, description="", lifecycle_state=LifecycleState.FINALIZED,
+        )
+        transition(case, LifecycleState.CONTESTED)
+        case.refresh_from_db()
+        self.assertEqual(case.lifecycle_state, LifecycleState.CONTESTED)

--- a/Suspicious/Suspicious/cortex_job/cortex_utils/case_targets.py
+++ b/Suspicious/Suspicious/cortex_job/cortex_utils/case_targets.py
@@ -1,0 +1,80 @@
+"""Shared artifact-walk for an existing Case — used both to build the
+AnalyzerReport query (investigations/submissions detail views) and to build
+Cortex dispatch intents (redo-analysis)."""
+from __future__ import annotations
+
+from django.db import models
+
+
+def collect_case_targets(case) -> list[tuple[models.Model, str]]:
+    """Walk case.fileOrMail / case.nonFileIocs and return every distinct
+    (instance, data_type) artifact linked to this case.
+
+    De-duplicated by (data_type, pk): the same URL/IP/hash/domain/mail
+    address can be referenced by more than one MailArtifact row on the
+    same mail, and callers that dispatch analyzers per target (unlike a
+    SQL `IN` filter, which silently absorbs list duplicates) must not see
+    the same artifact twice.
+    """
+    seen: dict[tuple[str, int], models.Model] = {}
+
+    def _add(instance, data_type: str) -> None:
+        if instance is None or instance.pk is None:
+            return
+        seen[(data_type, instance.pk)] = instance
+
+    file_or_mail = getattr(case, "fileOrMail", None)
+    non_file_iocs = getattr(case, "nonFileIocs", None)
+
+    if case.fileOrMail_id and file_or_mail:
+        if file_or_mail.file_id:
+            _add(file_or_mail.file, "file")
+
+        if file_or_mail.mail_id and getattr(file_or_mail, "mail", None):
+            mail = file_or_mail.mail
+
+            if mail.mail_body_id:
+                _add(mail.mail_body, "mail_body")
+            if mail.mail_header_id:
+                _add(mail.mail_header, "mail_header")
+
+            for attachment in mail.mail_attachments.exclude(file_id__isnull=True).select_related("file"):
+                _add(attachment.file, "file")
+
+            for artifact in mail.mail_artifacts.select_related(
+                "artifactIsUrl", "artifactIsUrl__url",
+                "artifactIsIp", "artifactIsIp__ip",
+                "artifactIsHash", "artifactIsHash__hash",
+                "artifactIsDomain", "artifactIsDomain__domain",
+                "artifactIsMailAddress", "artifactIsMailAddress__mail_address",
+            ):
+                if artifact.artifactIsUrl_id and artifact.artifactIsUrl and artifact.artifactIsUrl.url_id:
+                    url = artifact.artifactIsUrl.url
+                    _add(url, "url")
+                    if getattr(url, "analyzed_url_id", None):
+                        _add(url.analyzed_url, "url")
+                if artifact.artifactIsIp_id and artifact.artifactIsIp and artifact.artifactIsIp.ip_id:
+                    _add(artifact.artifactIsIp.ip, "ip")
+                if artifact.artifactIsHash_id and artifact.artifactIsHash and artifact.artifactIsHash.hash_id:
+                    _add(artifact.artifactIsHash.hash, "hash")
+                if artifact.artifactIsDomain_id and artifact.artifactIsDomain and artifact.artifactIsDomain.domain_id:
+                    _add(artifact.artifactIsDomain.domain, "domain")
+                if (
+                    artifact.artifactIsMailAddress_id
+                    and artifact.artifactIsMailAddress
+                    and artifact.artifactIsMailAddress.mail_address_id
+                ):
+                    _add(artifact.artifactIsMailAddress.mail_address, "mail")
+
+    if case.nonFileIocs_id and non_file_iocs:
+        if non_file_iocs.url_id:
+            url = non_file_iocs.url
+            _add(url, "url")
+            if getattr(url, "analyzed_url_id", None):
+                _add(url.analyzed_url, "url")
+        if non_file_iocs.ip_id:
+            _add(non_file_iocs.ip, "ip")
+        if non_file_iocs.hash_id:
+            _add(non_file_iocs.hash, "hash")
+
+    return [(instance, data_type) for (data_type, _pk), instance in seen.items()]

--- a/Suspicious/Suspicious/cortex_job/cortex_utils/case_targets.py
+++ b/Suspicious/Suspicious/cortex_job/cortex_utils/case_targets.py
@@ -78,3 +78,24 @@ def collect_case_targets(case) -> list[tuple[models.Model, str]]:
             _add(non_file_iocs.hash, "hash")
 
     return [(instance, data_type) for (data_type, _pk), instance in seen.items()]
+
+
+_FIELD_BY_TYPE = {
+    "file": "file_id", "mail_body": "mail_body_id", "mail_header": "mail_header_id",
+    "url": "url_id", "ip": "ip_id", "hash": "hash_id", "domain": "domain_id",
+    "mail": "mail_id",
+}
+
+
+def build_analyzer_report_filter(targets: list[tuple[models.Model, str]]) -> models.Q:
+    """Build the AnalyzerReport Q filter (OR of per-field `IN` clauses) from
+    collect_case_targets()'s output. Shared by investigations.py and
+    submissions.py so the id-bucketing/OR-Q glue lives in one place."""
+    ids_by_field: dict[str, list[int]] = {}
+    for instance, data_type in targets:
+        ids_by_field.setdefault(_FIELD_BY_TYPE[data_type], []).append(instance.pk)
+
+    query = models.Q()
+    for field, ids in ids_by_field.items():
+        query |= models.Q(**{f"{field}__in": ids})
+    return query

--- a/Suspicious/Suspicious/cortex_job/tests/test_case_targets.py
+++ b/Suspicious/Suspicious/cortex_job/tests/test_case_targets.py
@@ -1,0 +1,48 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from case_handler.models import Case, CaseHasNonFileIocs
+from cortex_job.cortex_utils.case_targets import collect_case_targets
+from hash_process.models import Hash
+from ip_process.models import IP
+from url_process.models import URL
+
+User = get_user_model()
+
+
+class CollectCaseTargetsTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="cct_user", password="pw-12345")
+
+    def test_case_with_no_links_returns_empty(self):
+        case = Case.objects.create(reporter=self.user, description="")
+        self.assertEqual(collect_case_targets(case), [])
+
+    def test_non_file_iocs_returns_url_ip_hash(self):
+        case = Case.objects.create(reporter=self.user, description="")
+        url = URL.objects.create(address="http://example.com")
+        ip = IP.objects.create(address="1.2.3.4")
+        h = Hash.objects.create(value="deadbeef")
+        iocs = CaseHasNonFileIocs.objects.create(case=case, url=url, ip=ip, hash=h)
+        case.nonFileIocs = iocs
+        case.save()
+
+        targets = collect_case_targets(case)
+
+        data_types = sorted(dt for _obj, dt in targets)
+        self.assertEqual(data_types, ["hash", "ip", "url"])
+        by_type = {dt: obj for obj, dt in targets}
+        self.assertEqual(by_type["url"].pk, url.pk)
+        self.assertEqual(by_type["ip"].pk, ip.pk)
+        self.assertEqual(by_type["hash"].pk, h.pk)
+
+    def test_non_file_iocs_partial_fields_only_returns_set_ones(self):
+        case = Case.objects.create(reporter=self.user, description="")
+        url = URL.objects.create(address="http://example.com")
+        iocs = CaseHasNonFileIocs.objects.create(case=case, url=url)
+        case.nonFileIocs = iocs
+        case.save()
+
+        targets = collect_case_targets(case)
+
+        self.assertEqual([dt for _obj, dt in targets], ["url"])

--- a/Suspicious/Suspicious/cortex_job/tests/test_case_targets.py
+++ b/Suspicious/Suspicious/cortex_job/tests/test_case_targets.py
@@ -1,10 +1,12 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.utils import timezone
 
-from case_handler.models import Case, CaseHasNonFileIocs
+from case_handler.models import Case, CaseHasFileOrMail, CaseHasNonFileIocs
 from cortex_job.cortex_utils.case_targets import collect_case_targets
 from hash_process.models import Hash
 from ip_process.models import IP
+from mail_feeder.models import ArtifactIsUrl, Mail, MailArtifact
 from url_process.models import URL
 
 User = get_user_model()
@@ -46,3 +48,48 @@ class CollectCaseTargetsTest(TestCase):
         targets = collect_case_targets(case)
 
         self.assertEqual([dt for _obj, dt in targets], ["url"])
+
+    def test_analyzed_url_produces_second_url_target(self):
+        """A URL that has been redirect-chased (analyzed_url set) must
+        surface both the original and the analyzed URL as separate "url"
+        targets, so AnalyzerReports keyed on either are found."""
+        case = Case.objects.create(reporter=self.user, description="")
+        analyzed = URL.objects.create(address="http://final.example")
+        original = URL.objects.create(address="http://redirect.example", analyzed_url=analyzed)
+        iocs = CaseHasNonFileIocs.objects.create(case=case, url=original)
+        case.nonFileIocs = iocs
+        case.save()
+
+        targets = collect_case_targets(case)
+
+        url_targets = [obj for obj, dt in targets if dt == "url"]
+        self.assertEqual(
+            sorted(u.pk for u in url_targets),
+            sorted([original.pk, analyzed.pk]),
+        )
+
+    def test_mail_artifact_duplicate_url_collapses_to_one_target(self):
+        """Two MailArtifact rows on the same mail that both point (via
+        ArtifactIsUrl) at the same underlying URL must collapse to a single
+        "url" target, not two."""
+        case = Case.objects.create(reporter=self.user, description="")
+        url = URL.objects.create(address="http://dup.example")
+        mail = Mail.objects.create(
+            subject="s", reportedBy="r", date=timezone.now(), to="t",
+        )
+
+        for _ in range(2):
+            artifact = MailArtifact.objects.create(mail=mail, artifact_type="URL")
+            link = ArtifactIsUrl.objects.create(url=url, artifact=artifact)
+            artifact.artifactIsUrl = link
+            artifact.save(update_fields=["artifactIsUrl"])
+
+        file_or_mail = CaseHasFileOrMail.objects.create(case=case, mail=mail)
+        case.fileOrMail = file_or_mail
+        case.save()
+
+        targets = collect_case_targets(case)
+
+        url_targets = [obj for obj, dt in targets if dt == "url"]
+        self.assertEqual(len(url_targets), 1)
+        self.assertEqual(url_targets[0].pk, url.pk)

--- a/suspicious-ui/src/features/investigation/api.ts
+++ b/suspicious-ui/src/features/investigation/api.ts
@@ -365,3 +365,10 @@ export async function editGlobalCase(
   const res = await api.patch(`/investigations/${caseId}/edit-global/`, payload);
   return normalizeDetails(res.data);
 }
+
+export async function redoAnalysis(
+  caseId: number,
+): Promise<{ status: string; dispatched: number }> {
+  const res = await api.post(`/investigations/${caseId}/redo-analysis/`);
+  return res.data;
+}

--- a/suspicious-ui/src/pages/InvestigationPage.tsx
+++ b/suspicious-ui/src/pages/InvestigationPage.tsx
@@ -10,6 +10,10 @@ import {
   CardContent,
   Chip,
   CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Divider,
   Drawer,
   FormControl,
@@ -40,6 +44,7 @@ import {
   CloseOutlined,
   ExpandMoreOutlined,
   RestartAltOutlined,
+  ReplayOutlined,
 } from "@mui/icons-material";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Skeleton } from "boneyard-js/react";
@@ -54,6 +59,7 @@ import {
   getAllInvestigations,
   getInvestigationDetails,
   editGlobalCase,
+  redoAnalysis,
   buildSortOrdering,
   type InvestigationDetails,
   type InvestigationListResponse,
@@ -237,6 +243,21 @@ export default function InvestigationPage() {
     },
   });
 
+  const redoMutation = useMutation({
+    mutationFn: (caseId: number) => redoAnalysis(caseId),
+    onSuccess: async () => {
+      // ponytail: detailsQuery.refetch() already covers this query directly;
+      // also invalidating ["investigationDetails"] would double-fire it
+      // since the query is active (invalidate + explicit refetch both fetch).
+      await Promise.all([
+        detailsQuery.refetch(),
+        investigationsQuery.refetch(),
+        qc.invalidateQueries({ queryKey: ["investigation"] }),
+      ]);
+    },
+  });
+  const [redoConfirmOpen, setRedoConfirmOpen] = React.useState(false);
+
   const commentsQuery = useQuery({
     queryKey: ["caseComments", selectedIdNum],
     queryFn: () => getCaseComments(selectedIdNum),
@@ -288,6 +309,8 @@ export default function InvestigationPage() {
 
   React.useEffect(() => {
     editMutation.reset();
+    redoMutation.reset();
+    setRedoConfirmOpen(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedId]);
 
@@ -998,6 +1021,29 @@ export default function InvestigationPage() {
                         Cancel
                       </Button>
                     ) : null}
+                    {detailsReady ? (
+                      <Tooltip
+                        title={
+                          detailsQuery.data?.status === "DONE" || detailsQuery.data?.status === "CHALLENGED"
+                            ? ""
+                            : "Case is still being analyzed."
+                        }
+                      >
+                        <span>
+                          <Button
+                            size="small"
+                            startIcon={<ReplayOutlined sx={{ fontSize: "13px !important" }} />}
+                            disabled={
+                              !(detailsQuery.data?.status === "DONE" || detailsQuery.data?.status === "CHALLENGED")
+                            }
+                            onClick={() => setRedoConfirmOpen(true)}
+                            sx={{ textTransform: "none", fontWeight: 800, borderRadius: 2, fontSize: 12, py: 0.3 }}
+                          >
+                            Redo analysis
+                          </Button>
+                        </span>
+                      </Tooltip>
+                    ) : null}
                   </Stack>
 
                   {detailsQuery.isLoading ? (
@@ -1205,6 +1251,43 @@ export default function InvestigationPage() {
           </Stack>
         )}
       </Drawer>
+
+      <Dialog open={redoConfirmOpen} onClose={() => setRedoConfirmOpen(false)}>
+        <DialogTitle>Redo analysis?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            This re-runs every analyzer for this case's artifacts. The current
+            verdict is cleared and the case goes back to in-progress. Prior
+            analyzer results stay visible as history, they are not deleted.
+            This may trigger billed or rate-limited external lookups.
+          </Typography>
+          {redoMutation.isError ? (
+            <Alert severity="error" sx={{ mt: 1.5 }}>
+              {(redoMutation.error as { response?: { data?: { detail?: string } } })
+                ?.response?.data?.detail ?? "Redo failed — please try again."}
+            </Alert>
+          ) : null}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRedoConfirmOpen(false)} disabled={redoMutation.isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="warning"
+            disabled={redoMutation.isPending || !hasNumericSelectedId}
+            startIcon={redoMutation.isPending ? <CircularProgress size={13} color="inherit" /> : <ReplayOutlined />}
+            onClick={() => {
+              if (!hasNumericSelectedId) return;
+              redoMutation.mutate(selectedIdNum, {
+                onSuccess: () => setRedoConfirmOpen(false),
+              });
+            }}
+          >
+            {redoMutation.isPending ? "Redoing…" : "Redo analysis"}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
     </Skeleton>
   );

--- a/suspicious-ui/src/pages/__tests__/InvestigationPage.test.tsx
+++ b/suspicious-ui/src/pages/__tests__/InvestigationPage.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@/features/investigation/api", () => ({
   getAllInvestigations: vi.fn(),
   getInvestigationDetails: vi.fn(),
   editGlobalCase: vi.fn(),
+  redoAnalysis: vi.fn(),
   buildSortOrdering: vi.fn((field: string, dir: string) => `${dir === "asc" ? "" : "-"}${field}`),
 }));
 
@@ -96,6 +97,7 @@ import { getMe } from "@/api/auth";
 import {
   getAllInvestigations,
   getInvestigationDetails,
+  redoAnalysis,
 } from "@/features/investigation/api";
 import InvestigationPage from "@/pages/InvestigationPage";
 import { getCaseComments, addCaseComment } from "@/features/comments/api";
@@ -105,6 +107,7 @@ const mockGetAll = vi.mocked(getAllInvestigations);
 const mockGetDetails = vi.mocked(getInvestigationDetails);
 const mockGetComments = vi.mocked(getCaseComments);
 const mockAddComment = vi.mocked(addCaseComment);
+const mockRedoAnalysis = vi.mocked(redoAnalysis);
 
 function renderInvestigation() {
   return renderWithProviders(<InvestigationPage />, { initialPath: "/investigation" });
@@ -331,5 +334,103 @@ describe("InvestigationPage", () => {
     await waitFor(() =>
       expect(mockAddComment).toHaveBeenCalledWith(7, "looks clean")
     );
+  });
+
+  describe("Redo analysis", () => {
+    it("is disabled while the case is not terminal", async () => {
+      const user = userEvent.setup();
+      mockGetDetails.mockResolvedValue({ ...mockDetails, status: "IN_PROGRESS" } as never);
+      renderInvestigation();
+
+      await waitFor(() =>
+        expect(screen.getByText(/phish\.evil\.com|reporter@corp/i)).toBeInTheDocument()
+      );
+      const row = screen.getByText(/phish\.evil\.com|reporter@corp/i).closest("tr") ??
+                  screen.getByText(/phish\.evil\.com|reporter@corp/i);
+      await user.click(row);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /redo analysis/i })).toBeDisabled();
+      });
+    });
+
+    it("opens a confirmation dialog before calling the API", async () => {
+      const user = userEvent.setup();
+      renderInvestigation(); // mockDetails.status is "DONE" (terminal) by default
+
+      await waitFor(() =>
+        expect(screen.getByText(/phish\.evil\.com|reporter@corp/i)).toBeInTheDocument()
+      );
+      const row = screen.getByText(/phish\.evil\.com|reporter@corp/i).closest("tr") ??
+                  screen.getByText(/phish\.evil\.com|reporter@corp/i);
+      await user.click(row);
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: /redo analysis/i })).toBeEnabled()
+      );
+      await user.click(screen.getByRole("button", { name: /redo analysis/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Redo analysis?")).toBeInTheDocument();
+      });
+      expect(mockRedoAnalysis).not.toHaveBeenCalled();
+    });
+
+    it("calls redoAnalysis and refetches details on confirm", async () => {
+      const user = userEvent.setup();
+      mockRedoAnalysis.mockResolvedValue({ status: "queued", dispatched: 1 });
+      renderInvestigation();
+
+      await waitFor(() =>
+        expect(screen.getByText(/phish\.evil\.com|reporter@corp/i)).toBeInTheDocument()
+      );
+      const row = screen.getByText(/phish\.evil\.com|reporter@corp/i).closest("tr") ??
+                  screen.getByText(/phish\.evil\.com|reporter@corp/i);
+      await user.click(row);
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: /redo analysis/i })).toBeEnabled()
+      );
+      await user.click(screen.getByRole("button", { name: /redo analysis/i }));
+      await waitFor(() => expect(screen.getByText("Redo analysis?")).toBeInTheDocument());
+
+      const dialog = screen.getByRole("dialog");
+      await user.click(within(dialog).getByRole("button", { name: /redo analysis/i }));
+
+      await waitFor(() => {
+        expect(mockRedoAnalysis).toHaveBeenCalledWith(7);
+      });
+      await waitFor(() => {
+        expect(mockGetDetails).toHaveBeenCalledTimes(2); // initial load + post-redo refetch
+      });
+    });
+
+    it("shows the server's error message on a 409", async () => {
+      const user = userEvent.setup();
+      mockRedoAnalysis.mockRejectedValue({
+        response: { status: 409, data: { detail: "Case is still being analyzed." } },
+      });
+      renderInvestigation();
+
+      await waitFor(() =>
+        expect(screen.getByText(/phish\.evil\.com|reporter@corp/i)).toBeInTheDocument()
+      );
+      const row = screen.getByText(/phish\.evil\.com|reporter@corp/i).closest("tr") ??
+                  screen.getByText(/phish\.evil\.com|reporter@corp/i);
+      await user.click(row);
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: /redo analysis/i })).toBeEnabled()
+      );
+      await user.click(screen.getByRole("button", { name: /redo analysis/i }));
+      await waitFor(() => expect(screen.getByText("Redo analysis?")).toBeInTheDocument());
+
+      const dialog = screen.getByRole("dialog");
+      await user.click(within(dialog).getByRole("button", { name: /redo analysis/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Case is still being analyzed.")).toBeInTheDocument();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds an investigator-only "Redo analysis" action: re-dispatches every applicable Cortex analyzer for a `FINALIZED`/`CONTESTED` case, resetting it to `ANALYZING` while keeping old `AnalyzerReport` rows as history.
- Extracts a shared `collect_case_targets(case)` helper (dedup'd by `(data_type, pk)`) used by both the investigations/submissions detail views and the new redo endpoint — replacing the duplicated artifact-walk that used to live in each view separately, and dropping the now-dead `.distinct()` on those querysets.
- Adds two new legal lifecycle transitions: `FINALIZED`/`CONTESTED` → `ANALYZING`, via the existing optimistic-locking `transition()` helper.
- New endpoint: `POST /api/investigations/<case_id>/redo-analysis/` — `IsInvestigator`-gated (CERT/CISO/Admin), 409 if case is non-terminal, 400 if no analyzable artifacts, clears verdict fields, dispatches through the existing `dispatch_case_analysis` Celery task (no new Cortex-calling code, no new per-case lock).
- Frontend: `redoAnalysis()` API client function plus a gated "Redo analysis" button + confirmation dialog in the investigation detail drawer, disabled with a tooltip while the case is non-terminal.

## Test plan
- [x] Backend: `api`, `case_handler`, `cortex_job` suites — 242/243 pass (the 1 failure is the pre-existing, unrelated `test_profile_avatar` presign-URL issue from PR #222, confirmed present on `main` before this branch too).
- [x] Frontend: full Vitest suite — 296/296 pass (47 files).
- [x] Manual browser pass against a live dev stack: logged in as an investigator, opened a `DONE`/terminal case, confirmed the dialog, hit the real endpoint (202), watched the case flip to `IN PROGRESS`/`INCONCLUSIVE`/score 0, then confirmed the button shows disabled with tooltip "Case is still being analyzed." on the now-non-terminal case.
- [x] Final whole-branch review (subagent-driven-development flow): Ready to merge — no Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)