### PR TITLE
fix(scoring): stop info level colliding with NEUTRAL

### DIFF
--- a/Suspicious/Suspicious/score_process/scoring/cortex_analyzers/default.py
+++ b/Suspicious/Suspicious/score_process/scoring/cortex_analyzers/default.py
@@ -19,7 +19,12 @@ def get_level_score_confidence(level: str) -> tuple[int, int]:
         case "suspicious":
             return 7, 70
         case "info":
-            return 5, 50
+            # Not 5: engine.NEUTRAL == 5 is the "no confident signal" sentinel,
+            # and "info" (analyzer added context, no security verdict — e.g.
+            # FileInfo's filetype tag) must not collide with it, or a mail with
+            # only neutral/informational findings gets forced to Inconclusive
+            # instead of banding Safe.
+            return 2, 50
         case "safe":
             return 0, 100
         case _:
@@ -30,7 +35,8 @@ class DefaultTaxonomyParser(AnalyzerParser):
     manifest = AnalyzerManifest(name="default", cortex_names=())
 
     def parse(self, summary: Any, full: Any) -> AnalyzerResult:
-        level, category, details, score, confidence = "info", [], {}, 5, 50
+        level, category, details = "info", [], {}
+        score, confidence = get_level_score_confidence(level)
 
         if isinstance(summary, dict) and summary.get("taxonomies"):
             tax_level = None

--- a/Suspicious/Suspicious/score_process/tests/test_analyzer_parsers.py
+++ b/Suspicious/Suspicious/score_process/tests/test_analyzer_parsers.py
@@ -99,6 +99,16 @@ class DefaultParserTests(SimpleTestCase):
         self.assertEqual(get_level_score_confidence("safe"), (0, 100))
         self.assertEqual(get_level_score_confidence("nonsense"), (0, 0))
 
+    def test_info_score_does_not_collide_with_neutral_sentinel(self):
+        from score_process.scoring.engine import NEUTRAL
+        score, _ = get_level_score_confidence("info")
+        self.assertNotEqual(
+            score, NEUTRAL,
+            "info (analyzer added context, no security verdict) must not "
+            "share engine.NEUTRAL's value or a mail with only info-level "
+            "findings gets forced to Inconclusive instead of Safe.",
+        )
+
     def test_fileinfo_fixture_parses_info(self):
         f = load_fixture("fileinfo")
         r = self._mk().parse(f["summary"], f["full"])
@@ -210,7 +220,7 @@ class ZscalerParserTests(SimpleTestCase):
     def test_benign_is_info(self):
         r = self._run("zscaler")
         self.assertEqual(r.level, "info")
-        self.assertEqual(r.score, 5)
+        self.assertEqual(r.score, 2)
         self.assertIn("CORPORATE_MARKETING", r.category)
 
     def test_security_alert_is_malicious(self):

--- a/Suspicious/Suspicious/score_process/tests/test_engine.py
+++ b/Suspicious/Suspicious/score_process/tests/test_engine.py
@@ -85,6 +85,14 @@ class ScoreCaseTest(SimpleTestCase):
         v = score_case([sig(1, 90), sig(2, 90)])
         self.assertEqual(v.result, Result.SAFE)
 
+    def test_info_only_signal_is_safe_not_inconclusive(self):
+        """Regression: an 'info'-level analyzer (e.g. FileInfo, present on
+        every attachment) used to score exactly NEUTRAL(5), forcing a case
+        with no other findings to Inconclusive even when nothing suspicious
+        was ever found. get_level_score_confidence('info') now returns 2."""
+        v = score_case([sig(2, 50)])
+        self.assertEqual(v.result, Result.SAFE)
+
     def test_final_score_and_result_agree_on_non_integer_mean(self):
         v = score_case([sig(4, 60), sig(5, 40)])
         self.assertEqual(v.final_score, 4)


### PR DESCRIPTION


## Description

get_level_score_confidence(info) renvoyait 5, identique au sentinel NEUTRAL du moteur. Un mail sain avec seulement des analyzers info (ex: FileInfo) tombait donc en Inconclusive au lieu de Safe. Passe a 2.

## Related issues

<!-- Closes #123 -->

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behavior change
- [ ] `chore` / `ci` / `build` / `test`

## Checklist

- [ ] `python manage.py test` passes (backend changes)
- [ ] `pnpm lint` and `pnpm test` pass (frontend changes)
- [ ] Documentation updated where relevant
- [ ] Commit messages follow Conventional Commits
