### PR TITLE
fix(ui): restore scroll in investigations drawer

### DIFF
--- a/suspicious-ui/src/pages/InvestigationPage.tsx
+++ b/suspicious-ui/src/pages/InvestigationPage.tsx
@@ -889,12 +889,13 @@ export default function InvestigationPage() {
               </Stack>
             </Box>
 
+            <Box sx={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
             <Skeleton
               name="investigation-drawer-details"
               loading={detailsQuery.isFetching && detailsQuery.isPlaceholderData}
               animate="shimmer"
             >
-            <Box sx={{ flex: 1, overflowY: "auto" }}>
+            <Box>
 
               {/* ── Allow/deny-list banner ────────────────────────────────────── */}
               {(detailsQuery.data?.is_allowlisted || detailsQuery.data?.is_denylisted) ? (
@@ -1264,6 +1265,7 @@ export default function InvestigationPage() {
               </Stack>
             </Box>
             </Skeleton>
+            </Box>
           </Stack>
         )}
       </Drawer>


### PR DESCRIPTION
## Summary
- Investigations drawer content couldn't scroll; Submissions drawer could.
- Root cause: the scrollable `Box` (`flex:1, overflowY:auto`) was nested inside boneyard-js's `<Skeleton>`, which wraps children in plain non-flex `div`s — so `flex:1` had no flex parent and never clipped, meaning `overflowY:auto` never engaged.
- Fix: moved the scroll container outside `Skeleton`, as a direct flex child of the drawer's `Stack`, matching the Submissions drawer's structure.

## Test plan
- [x] `pnpm lint` — no new errors (4 pre-existing unrelated warnings)
- [x] `tsc --noEmit` — clean
- [x] Manual: open an investigation with enough content to overflow the drawer, confirm scroll works