### PR TITLE
ci: skip system checks for DB-less manage.py commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
             -v "${{ github.workspace }}/Suspicious/settings.ci.json":/app/settings.json:ro \
             -e SUSPICIOUS_CONFIG_PATH=/app/settings.json -w /app/Suspicious \
             suspicious:ci \
-            python manage.py makemigrations --check --dry-run --settings=suspicious.settings
+            python manage.py makemigrations --check --dry-run --skip-checks --settings=suspicious.settings
 
   backend-test:
     needs: changes

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,7 @@ jobs:
             suspicious:ci \
             python manage.py spectacular \
               --settings=suspicious.settings \
+              --skip-checks \
               --file /docs/reference/openapi.yaml
           test -s docs/reference/openapi.yaml
 


### PR DESCRIPTION
## Why

#286 (django 6.0.7 → 6.1) fails `migration-check` and the Docs `build` job with:

```
django.db.utils.OperationalError: (2005, "Unknown server host 'db_suspicious' (-2)")
```

Root cause: Django 6.1's MySQL backend added `has_native_uuid_field` support (MariaDB 10.7+ has a native UUID column type). Computing `db_type()` for `file_process.File`'s `UUIDField` primary key now checks `connection.mysql_is_mariadb`, which opens a live connection to determine the server vendor/version — something 6.0.7 never needed.

Both `ci.yml`'s `migration-check` and `docs.yml`'s `build` job run `manage.py` standalone (`docker run`, no DB service attached), so this connection was never available and previously never required. Neither `makemigrations --check --dry-run` nor `spectacular` needs model validity checks — they're schema/diff tools, not runtime commands — so this passes `--skip-checks` to both instead of standing up a DB service in CI.

## Verification

Reproduced locally by building the backend image with `django==6.1` and running each job's exact command:
- `makemigrations --check --dry-run` (no `--skip-checks`): crashes with the `OperationalError` above.
- Same command + `--skip-checks`: exits 0, `No changes detected` (same as the pre-existing non-fatal `RuntimeWarning` django 6.0.7 already logs for the same unreachable host).
- `manage.py spectacular --skip-checks`: exits 0, generates a valid `openapi.yaml` (2951 lines).

## Test plan

- [ ] CI green on this PR
- [ ] Rebase/re-run #286 once this merges — `migration-check` and Docs `build` should go green