### PR TITLE
ci: restrict sha- image tags to releases, add GHCR cleanup

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,39 @@
+name: GHCR cleanup
+
+on:
+  schedule:
+    - cron: "0 3 * * 0" # weekly, Sunday 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  prune-untagged:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [suspicious, suspicious-ui, suspicious-feeder]
+    steps:
+      # Every image push (release.yml, on every main-branch push) also pushes
+      # a SLSA provenance attestation as a separate, untagged package version
+      # (0 downloads — it's only ever referenced, never pulled directly).
+      # min-versions-to-keep: 0 + delete-only-untagged-versions: true is the
+      # standard idiom for "delete every untagged version, touch nothing
+      # tagged" — latest/semver/sha-* versions are never candidates.
+      #
+      # GITHUB_TOKEN can't delete versions of org-owned GHCR packages (no
+      # delete scope for org packages). Add a classic PAT with read:packages
+      # + delete:packages as the GHCR_CLEANUP_TOKEN repo secret, or this job
+      # fails with a 403.
+      - name: Delete untagged versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ matrix.package }}
+          package-type: container
+          org: thalesgroup-cert
+          token: ${{ secrets.GHCR_CLEANUP_TOKEN }}
+          min-versions-to-keep: 0
+          delete-only-untagged-versions: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,12 @@ jobs:
           images: ${{ matrix.image }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix=sha-,enable={{is_default_branch}}
+            # sha-<commit> only on an actual release (a v* tag push), not on
+            # every ordinary main-branch push — that was flooding GHCR with a
+            # tagged image (+ provenance attestation) per merge. is_default_branch
+            # is false for tag-push events, so this and the `latest` line above
+            # are mutually exclusive triggers.
+            type=sha,prefix=sha-,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=test,enable=${{ github.ref == 'refs/heads/test' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
## Problem

`release.yml` runs on every push to `main` (to keep `latest` fresh), but was also tagging every one of those pushes `sha-<commit>` — `enable={{is_default_branch}}` matches any main push, not the `v*` tag pushes that are actual releases. Each push additionally leaves an untagged SLSA provenance attestation version (0 downloads, only ever referenced via the OCI "referrers" convention, never pulled directly). Net effect: 2 new GHCR package versions per image per merge, flooding the package pages.

## Fix

- **`release.yml`**: gate the `sha-` tag on `startsWith(github.ref, 'refs/tags/v')` instead of `is_default_branch`, so it only appears on real releases. `latest` still refreshes on every main push, unchanged.
- **`ghcr-cleanup.yml`** (new): weekly (+ `workflow_dispatch`) job that deletes untagged package versions — the orphaned attestations — for all three images (`suspicious`, `suspicious-ui`, `suspicious-feeder`) via `actions/delete-package-versions`. Tagged versions (`latest`, semver, `sha-*`) are never touched.

## Action needed

`GITHUB_TOKEN` can't delete versions of org-owned GHCR packages (no delete scope there). Add a classic PAT with `read:packages` + `delete:packages` as the **`GHCR_CLEANUP_TOKEN`** repo secret, or the cleanup job 403s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)