### PR TITLE
fix(ui): serialize vitest file execution to kill browser-mode flake

### DIFF
--- a/suspicious-ui/vitest.config.ts
+++ b/suspicious-ui/vitest.config.ts
@@ -37,6 +37,16 @@ export default mergeConfig(
       setupFiles: ["./src/test/setup.ts"],
       include: ["src/**/*.test.{ts,tsx}"],
       exclude: ["e2e/**", "node_modules/**"],
+      // Parallel file execution in browser mode shares module/dep state
+      // across the concurrently-running suites (same class of issue as the
+      // optimizeDeps race above), which has surfaced as spurious CI failures
+      // in unrelated files — a vi.mock'd module resolving to its real,
+      // unmocked implementation (api.test.ts: "vi.mocked(...).mockResolvedValue
+      // is not a function") or an unrelated assertion failing outright
+      // (ProfilePage.test.tsx). Serializing file execution has been 100%
+      // reliable locally across many runs (and finishes in under a minute for
+      // this suite size) vs. an intermittent per-file flake under parallelism.
+      fileParallelism: false,
       browser: {
         enabled: true,
         provider: playwright(),


### PR DESCRIPTION
## Root cause

CI's `frontend` job has been intermittently failing one random file per run under the default parallel file execution:
- `api.test.ts`: `TypeError: vi.mocked(...).mockResolvedValue is not a function` — a `vi.mock`'d module resolving to its real, unmocked implementation
- `ProfilePage.test.tsx`: an unrelated assertion failing outright

Same class of issue already documented in this file's `optimizeDeps` comment: vitest browser mode shares dep/module state across concurrently-running suites, so a file resolving/re-importing mid-run can knock out a sibling file's mocked module or in-flight fetch.

Every UI-touching PR in the last dependency batch needed at least one `gh run rerun --failed` because of this.

## Fix

`test.fileParallelism: false` in `vitest.config.ts`. Verified locally (plain `pnpm test` / `vitest run`, no flags) — **47/47 files, 299/299 tests, reliably, across many runs** — and it's actually *faster* end-to-end (~50s) than a parallel run that has to retry/rerun on flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)