### PR TITLE
fix(rbac): CISO group on CISOProfile + scope-filtered investigations

### DIFF
--- a/Suspicious/Suspicious/api/serializers/auth.py
+++ b/Suspicious/Suspicious/api/serializers/auth.py
@@ -70,8 +70,10 @@ class AuthenticatedUserSerializer(serializers.ModelSerializer):
         return list(obj.groups.values_list("name", flat=True))
 
     def get_ciso_scope(self, obj) -> str:
+        from profiles.profiles_utils.scope import clean_scope
+
         try:
-            return obj.cisoprofile.scope or ""
+            return clean_scope(obj.cisoprofile.scope) or ""
         except CISOProfile.DoesNotExist:
             return ""
 

--- a/Suspicious/Suspicious/api/serializers/profile.py
+++ b/Suspicious/Suspicious/api/serializers/profile.py
@@ -235,7 +235,30 @@ class CISOProfileSerializer(serializers.ModelSerializer):
             "creation_date",
             "last_update",
         ]
-        read_only_fields = ["id", "scope", "creation_date", "last_update"]
+        read_only_fields = ["id", "creation_date", "last_update"]
+
+    def validate_scope(self, value):
+        """A CISO may only scope themselves to "ALL" or a pipe-joined subset
+        of their own org units (region / country / gbu). This stops a CISO
+        widening their own visibility to an arbitrary group."""
+        normalized = (value or "").strip()
+        if not normalized or normalized.upper() == "ALL":
+            return "ALL" if normalized else normalized
+
+        instance = self.instance
+        allowed = {
+            str(getattr(instance, attr, "") or "").strip()
+            for attr in ("region", "country", "gbu")
+        }
+        allowed.discard("")
+
+        parts = [p.strip() for p in normalized.split("|") if p.strip()]
+        invalid = [p for p in parts if p not in allowed]
+        if not parts or invalid:
+            raise serializers.ValidationError(
+                f"Invalid scope. Allowed values: {sorted(allowed) + ['ALL']}."
+            )
+        return "|".join(parts)
 
     def validate_theme(self, value):
         valid = {choice[0] for choice in Theme.choices}

--- a/Suspicious/Suspicious/api/tests/test_security_access.py
+++ b/Suspicious/Suspicious/api/tests/test_security_access.py
@@ -93,6 +93,102 @@ class InvestigationAccessTests(TestCase):
         self.assertEqual(resp.status_code, 200)
 
 
+class CISOProfileGroupSignalTests(TestCase):
+    """A CISOProfile must grant the CISO group — every RBAC check keys off it."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_profile_creation_grants_group(self):
+        from profiles.models import CISOProfile
+
+        user = _make_user("ciso_sig")
+        self.assertFalse(user.groups.filter(name="CISO").exists())
+        CISOProfile.objects.create(user=user)
+        self.assertTrue(user.groups.filter(name="CISO").exists())
+
+    def test_profile_deletion_revokes_group(self):
+        from profiles.models import CISOProfile
+
+        user = _make_user("ciso_sig_del")
+        profile = CISOProfile.objects.create(user=user)
+        profile.delete()
+        self.assertFalse(user.groups.filter(name="CISO").exists())
+
+    def test_ciso_profile_user_can_reach_investigations(self):
+        from profiles.models import CISOProfile
+
+        user = _make_user("ciso_access")
+        CISOProfile.objects.create(user=user, scope="ALL")
+        self.client.force_authenticate(user)
+        resp = self.client.get(reverse("investigation-list"))
+        self.assertEqual(resp.status_code, 200)
+
+
+class CISOInvestigationScopeTests(TestCase):
+    def setUp(self):
+        from profiles.models import CISOProfile
+
+        self.client = APIClient()
+        # _make_user() get_or_creates each named group.
+        self.emea_reporter = _make_user("emea_rep", groups=["EMEA"])
+        self.apac_reporter = _make_user("apac_rep", groups=["APAC"])
+        self.emea_case = Case.objects.create(reporter=self.emea_reporter, description="emea")
+        self.apac_case = Case.objects.create(reporter=self.apac_reporter, description="apac")
+
+        self.ciso = _make_user("scoped_ciso")
+        self.profile = CISOProfile.objects.create(
+            user=self.ciso, region="EMEA", country="FR", gbu="MG", scope="EMEA"
+        )
+
+    def _ids(self, resp):
+        return {row["id"] for row in resp.data["results"]}
+
+    def test_list_is_scope_filtered(self):
+        self.client.force_authenticate(self.ciso)
+        resp = self.client.get(reverse("investigation-list"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(self._ids(resp), {self.emea_case.id})
+
+    def test_detail_out_of_scope_is_404(self):
+        self.client.force_authenticate(self.ciso)
+        resp = self.client.get(
+            reverse("investigation-details", kwargs={"case_id": self.apac_case.id})
+        )
+        self.assertEqual(resp.status_code, 404)
+
+    def test_unset_scope_sees_nothing(self):
+        self.profile.scope = "Not defined"
+        self.profile.save()
+        self.client.force_authenticate(self.ciso)
+        resp = self.client.get(reverse("investigation-list"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(self._ids(resp), set())
+
+    def test_all_scope_sees_everything(self):
+        self.profile.scope = "ALL"
+        self.profile.save()
+        self.client.force_authenticate(self.ciso)
+        resp = self.client.get(reverse("investigation-list"))
+        self.assertEqual(self._ids(resp), {self.emea_case.id, self.apac_case.id})
+
+    def test_cert_is_not_scope_filtered(self):
+        cert = _make_user("scope_cert", groups=["CERT"])
+        self.client.force_authenticate(cert)
+        resp = self.client.get(reverse("investigation-list"))
+        self.assertEqual(self._ids(resp), {self.emea_case.id, self.apac_case.id})
+
+    def test_scope_set_via_profile_patch(self):
+        self.client.force_authenticate(self.ciso)
+        resp = self.client.patch(reverse("profile"), {"scope": "APAC"}, format="json")
+        # APAC is not one of this CISO's own org units -> rejected
+        self.assertEqual(resp.status_code, 400)
+        resp = self.client.patch(reverse("profile"), {"scope": "FR"}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.scope, "FR")
+
+
 class DashboardPerUserStatsAccessTests(TestCase):
     """Regression for the per-user-stats data leak: regular reporters must
     not be able to enumerate colleague-level case counts."""

--- a/Suspicious/Suspicious/api/views/home.py
+++ b/Suspicious/Suspicious/api/views/home.py
@@ -12,6 +12,7 @@ from api.serializers.home import (
 from case_handler.models import Case
 from dashboard.models import GroupMonthlyStats, UserCasesMonthlyStats, TotalCasesStats
 from profiles.models import CISOProfile, UserProfile
+from profiles.profiles_utils.scope import clean_scope, parse_scope_groups
 
 
 @extend_schema(
@@ -48,7 +49,7 @@ class HomeSummaryView(APIView):
         ciso_profile = CISOProfile.objects.filter(user=request.user).first()
         active_profile = ciso_profile if is_ciso and ciso_profile else user_profile
 
-        ciso_scope = self._clean_scope(getattr(ciso_profile, "scope", None)) if ciso_profile else None
+        ciso_scope = clean_scope(getattr(ciso_profile, "scope", None)) if ciso_profile else None
         show_scope_modal = bool(is_ciso and not ciso_scope)
 
         personal_stats = self._aggregate_user_stats(
@@ -134,7 +135,7 @@ class HomeSummaryView(APIView):
     def _aggregate_scope_stats(cls, *, scope: str, month: str, year: str) -> dict:
         qs = GroupMonthlyStats.objects.filter(month=month, year=year)
 
-        scope_groups = cls._parse_scope_groups(scope)
+        scope_groups = parse_scope_groups(scope)
         if scope_groups is not None:
             qs = qs.filter(group_name__in=scope_groups)
 
@@ -172,27 +173,6 @@ class HomeSummaryView(APIView):
             return None
         normalized = str(value).strip()
         return normalized or None
-
-    @staticmethod
-    def _clean_scope(value):
-        if value is None:
-            return None
-        normalized = str(value).strip()
-        if not normalized or normalized.lower() == "not defined":
-            return None
-        return normalized
-
-    @staticmethod
-    def _parse_scope_groups(scope: str):
-        if not scope:
-            return []
-
-        normalized = scope.strip()
-        if normalized.upper() == "ALL":
-            return None
-
-        parts = [part.strip() for part in normalized.split("|")]
-        return [part for part in parts if part]
 
     @staticmethod
     def _build_spotlight(is_ciso: bool, is_cert: bool, total_cases: int, challenge_cases: int):

--- a/Suspicious/Suspicious/api/views/investigations.py
+++ b/Suspicious/Suspicious/api/views/investigations.py
@@ -25,6 +25,7 @@ from api.serializers.investigations import (
     InvestigationRowSerializer,
 )
 from score_process.score_utils.send_mail.service import MailNotificationService
+from profiles.profiles_utils.scope import scoped_case_queryset
 
 logger = logging.getLogger(__name__)
 
@@ -119,10 +120,13 @@ class InvestigationAccessMixin:
     analyzer_report_select_related = ANALYZER_REPORT_SELECT_RELATED
 
     def get_case_list_queryset(self):
-        return Case.objects.select_related(*CASE_LIST_SELECT_RELATED)
+        return scoped_case_queryset(
+            Case.objects.select_related(*CASE_LIST_SELECT_RELATED),
+            self.request.user,
+        )
 
     def get_case_detail_queryset(self):
-        return (
+        return scoped_case_queryset(
             Case.objects.select_related(*CASE_DETAIL_SELECT_RELATED)
             .prefetch_related(
                 "fileOrMail__mail__mail_attachments",
@@ -132,7 +136,8 @@ class InvestigationAccessMixin:
                 "fileOrMail__mail__mail_artifacts__artifactIsHash",
                 "fileOrMail__mail__mail_artifacts__artifactIsDomain",
                 "fileOrMail__mail__mail_artifacts__artifactIsMailAddress",
-            )
+            ),
+            self.request.user,
         )
 
     def get_case_or_404(self, case_id: int) -> Case:

--- a/Suspicious/Suspicious/profiles/apps.py
+++ b/Suspicious/Suspicious/profiles/apps.py
@@ -6,3 +6,6 @@ class ProfilesConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     
     verbose_name = "Profiles"
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/Suspicious/Suspicious/profiles/migrations/0014_backfill_ciso_group.py
+++ b/Suspicious/Suspicious/profiles/migrations/0014_backfill_ciso_group.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+def grant_ciso_group(apps, schema_editor):
+    CISOProfile = apps.get_model("profiles", "CISOProfile")
+    Group = apps.get_model("auth", "Group")
+    group, _ = Group.objects.get_or_create(name="CISO")
+    for profile in CISOProfile.objects.select_related("user").iterator():
+        profile.user.groups.add(group)
+
+
+def noop(apps, schema_editor):
+    # Deliberately not removing users from the CISO group on reverse — a
+    # profile deleted after this migration would already have been handled
+    # by the post_delete signal, and admins may have granted the group by
+    # other means.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("profiles", "0013_cisoprofile_sidebar_pinned_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(grant_ciso_group, noop),
+    ]

--- a/Suspicious/Suspicious/profiles/profiles_utils/scope.py
+++ b/Suspicious/Suspicious/profiles/profiles_utils/scope.py
@@ -1,0 +1,57 @@
+"""CISO scope helpers.
+
+A CISOProfile.scope is a pipe-delimited list of org-unit group names
+(e.g. "EMEA|FR"), the literal "ALL", or unset ("Not defined" / "").
+A case belongs to a scope when its reporter is in one of those groups —
+the same rule dashboard.update_group_monthly_stats uses.
+"""
+from __future__ import annotations
+
+
+def clean_scope(value) -> str | None:
+    """Normalise a raw scope value. Returns None when effectively unset."""
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    if not normalized or normalized.lower() == "not defined":
+        return None
+    return normalized
+
+
+def parse_scope_groups(scope: str | None):
+    """Group names a scope resolves to.
+
+    Returns None for "ALL" (meaning: no restriction), a list of group
+    names otherwise (possibly empty).
+    """
+    cleaned = clean_scope(scope)
+    if cleaned is None:
+        return []
+    if cleaned.upper() == "ALL":
+        return None
+    return [part.strip() for part in cleaned.split("|") if part.strip()]
+
+
+def scoped_case_queryset(queryset, user):
+    """Restrict a Case queryset to what ``user`` may see.
+
+    CERT/Admin and non-CISO users: unrestricted.
+    CISO with scope "ALL": unrestricted.
+    CISO with a real scope: cases whose reporter is in a scope group.
+    CISO with an unset scope: nothing (the UI prompts them to set one).
+    """
+    from profiles.models import CISOProfile
+
+    if user.groups.filter(name__in=["CERT", "Admin"]).exists():
+        return queryset
+    try:
+        ciso_profile = user.cisoprofile
+    except CISOProfile.DoesNotExist:
+        return queryset
+
+    groups = parse_scope_groups(ciso_profile.scope)
+    if groups is None:
+        return queryset
+    if not groups:
+        return queryset.none()
+    return queryset.filter(reporter__groups__name__in=groups).distinct()

--- a/Suspicious/Suspicious/profiles/signals.py
+++ b/Suspicious/Suspicious/profiles/signals.py
@@ -1,0 +1,40 @@
+"""Keep the ``CISO`` auth group in sync with CISOProfile rows.
+
+Every RBAC check (api IsInvestigator, ProtectedRoute, home, dashboard)
+keys off membership in the ``CISO`` group, but the CISOProfile creation
+paths (LDAP sync, profiles_utils.ciso.process_cisos, admin import) only
+ever create the profile. This signal is the single chokepoint that
+grants — and revokes — the group alongside the profile.
+"""
+import logging
+
+from django.contrib.auth.models import Group
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from profiles.models import CISOProfile
+
+logger = logging.getLogger("profiles")
+
+CISO_GROUP = "CISO"
+
+
+@receiver(post_save, sender=CISOProfile, dispatch_uid="ciso_profile_grant_group")
+def grant_ciso_group(sender, instance, created, **kwargs):
+    if not created:
+        return
+    group, _ = Group.objects.get_or_create(name=CISO_GROUP)
+    instance.user.groups.add(group)
+    logger.info("Added user %r to the %s group (CISOProfile created).",
+                instance.user.username, CISO_GROUP)
+
+
+@receiver(post_delete, sender=CISOProfile, dispatch_uid="ciso_profile_revoke_group")
+def revoke_ciso_group(sender, instance, **kwargs):
+    try:
+        group = Group.objects.get(name=CISO_GROUP)
+    except Group.DoesNotExist:
+        return
+    instance.user.groups.remove(group)
+    logger.info("Removed user %r from the %s group (CISOProfile deleted).",
+                instance.user.username, CISO_GROUP)

--- a/suspicious-ui/src/features/home/api.ts
+++ b/suspicious-ui/src/features/home/api.ts
@@ -1,0 +1,45 @@
+import { api } from "@/api/client";
+
+export type DangerCounts = {
+  safe?: number;
+  inconclusive?: number;
+  suspicious?: number;
+  dangerous?: number;
+};
+
+export type HomeSummary = {
+  show_scope_modal: boolean;
+  monthly: {
+    everyone_items?: number;
+    scope_items?: number;
+    scope_name?: string | null;
+  };
+  danger_counts?: DangerCounts;
+  scope_danger_counts?: DangerCounts | null;
+  suggested_scopes?: {
+    region?: string | null;
+    country?: string | null;
+    gbu?: string | null;
+  };
+  spotlight?: {
+    title: string;
+    description: string;
+    cta_label: string;
+    cta_path: string;
+  };
+};
+
+export async function getHomeSummary(params?: {
+  month?: number;
+  year?: number;
+}): Promise<HomeSummary> {
+  const res = await api.get("/home/summary/", { params });
+  return res.data;
+}
+
+/** Set the caller's CISO management scope. "ALL" or a pipe-joined subset of
+ *  their own region/country/gbu (validated server-side). */
+export async function setCisoScope(input: { scope: string }): Promise<{ scope: string }> {
+  const res = await api.patch("/profile/", input);
+  return res.data;
+}

--- a/suspicious-ui/src/features/home/components/CisoScopeDialog.tsx
+++ b/suspicious-ui/src/features/home/components/CisoScopeDialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react";
+import {
+  Alert,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { alpha, useTheme } from "@mui/material/styles";
+import { ApartmentOutlined, PublicOutlined } from "@mui/icons-material";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { getHomeSummary, setCisoScope } from "@/features/home/api";
+
+/**
+ * The "select your management scope" modal shown to a CISO who has no scope
+ * set yet — on first connection (Home) and when they open Investigation.
+ * Forced modal: no dismiss until a scope is confirmed.
+ */
+export function CisoScopeDialog({ open }: { open: boolean }) {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === "dark";
+  const qc = useQueryClient();
+
+  const [scopeChoice, setScopeChoice] = React.useState("");
+
+  const now = React.useMemo(() => new Date(), []);
+  const summaryQuery = useQuery({
+    queryKey: ["homeSummary", now.getMonth() + 1, now.getFullYear()],
+    queryFn: () => getHomeSummary({ month: now.getMonth() + 1, year: now.getFullYear() }),
+    enabled: open,
+    retry: false,
+  });
+
+  const suggested = summaryQuery.data?.suggested_scopes ?? {};
+
+  const scopeMutation = useMutation({
+    mutationFn: setCisoScope,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["me"] });
+      qc.invalidateQueries({ queryKey: ["homeSummary"] });
+      qc.invalidateQueries({ queryKey: ["investigation"] });
+    },
+  });
+
+  return (
+    <Dialog open={open} maxWidth="sm" fullWidth>
+      <DialogTitle>Select your management scope</DialogTitle>
+      <DialogContent>
+        <Stack spacing={1.25} sx={{ mt: 1 }}>
+          <Typography color="text.secondary">
+            This controls dashboards, investigations and submission visibility for your CISO view.
+          </Typography>
+
+          <Card
+            sx={{
+              borderRadius: 3,
+              border: `1px solid ${alpha(theme.palette.divider, isDark ? 0.18 : 0.7)}`,
+              background: isDark
+                ? "linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.03))"
+                : `linear-gradient(180deg, ${alpha("#fff", 0.88)}, ${alpha(theme.palette.grey[50], 0.96)})`,
+            }}
+          >
+            <CardContent>
+              <Stack spacing={1}>
+                <Typography sx={{ fontWeight: 900 }}>Suggested scopes</Typography>
+
+                <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap" }}>
+                  {suggested.region ? (
+                    <Chip
+                      icon={<PublicOutlined />}
+                      label={`Region: ${suggested.region}`}
+                      clickable
+                      onClick={() => setScopeChoice(suggested.region ?? "")}
+                      variant={scopeChoice === suggested.region ? "filled" : "outlined"}
+                    />
+                  ) : null}
+
+                  {suggested.country ? (
+                    <Chip
+                      icon={<ApartmentOutlined />}
+                      label={`Country: ${suggested.country}`}
+                      clickable
+                      onClick={() => setScopeChoice(suggested.country ?? "")}
+                      variant={scopeChoice === suggested.country ? "filled" : "outlined"}
+                    />
+                  ) : null}
+
+                  {suggested.gbu ? (
+                    <Chip
+                      label={`GBU: ${suggested.gbu}`}
+                      clickable
+                      onClick={() => setScopeChoice(suggested.gbu ?? "")}
+                      variant={scopeChoice === suggested.gbu ? "filled" : "outlined"}
+                    />
+                  ) : null}
+
+                  <Chip
+                    label="All cases"
+                    clickable
+                    onClick={() => setScopeChoice("ALL")}
+                    variant={scopeChoice === "ALL" ? "filled" : "outlined"}
+                  />
+
+                  {!suggested.region && !suggested.country && !suggested.gbu ? (
+                    <Chip label="No org-unit suggestions" variant="outlined" />
+                  ) : null}
+                </Stack>
+
+                <Typography variant="caption" color="text.secondary">
+                  You can change it later from your profile if your responsibilities change.
+                </Typography>
+
+                {scopeMutation.isError ? (
+                  <Alert severity="error">Failed to set scope.</Alert>
+                ) : null}
+              </Stack>
+            </CardContent>
+          </Card>
+        </Stack>
+      </DialogContent>
+
+      <DialogActions>
+        <Button
+          variant="contained"
+          disabled={!scopeChoice || scopeMutation.isPending}
+          onClick={() => scopeMutation.mutate({ scope: scopeChoice })}
+          sx={{ borderRadius: 3, textTransform: "none", fontWeight: 950 }}
+        >
+          {scopeMutation.isPending ? "Saving…" : "Confirm scope"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/suspicious-ui/src/pages/HomePage.tsx
+++ b/suspicious-ui/src/pages/HomePage.tsx
@@ -3,14 +3,8 @@ import {
   Alert,
   Box,
   Button,
-  Card,
-  CardContent,
   Chip,
   CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
   Divider,
   Grid,
   IconButton,
@@ -25,10 +19,8 @@ import {
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import {
-  ApartmentOutlined,
   ManageSearchOutlined,
   OpenInNewOutlined,
-  PublicOutlined,
   RocketLaunchOutlined,
   LeaderboardOutlined,
   UploadFileOutlined,
@@ -36,7 +28,7 @@ import {
   HistoryOutlined,
 } from "@mui/icons-material";
 import { useNavigate, Link as RouterLink } from "react-router";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useTheme } from "@mui/material/styles";
 import { useThemeMode, type ThemeCapabilities } from "@/styles/ThemeStore";
 import { api } from "@/api/client";
@@ -56,6 +48,12 @@ import FeederHealthBadge from "@/shared/components/FeederHealthBadge";
 
 import { DashboardCard } from "@/features/home/components/DashboardCard";
 import { ThemeGreeting } from "@/features/home/components/ThemeGreeting";
+import { CisoScopeDialog } from "@/features/home/components/CisoScopeDialog";
+import {
+  getHomeSummary,
+  type DangerCounts,
+  type HomeSummary,
+} from "@/features/home/api";
 import {
   DANGER_COLORS,
   DANGER_ORDER,
@@ -68,35 +66,6 @@ import {
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-type DangerCounts = {
-  safe?: number;
-  inconclusive?: number;
-  suspicious?: number;
-  dangerous?: number;
-};
-
-type HomeSummary = {
-  show_scope_modal: boolean;
-  monthly: {
-    everyone_items?: number;
-    scope_items?: number;
-    scope_name?: string | null;
-  };
-  danger_counts?: DangerCounts;
-  scope_danger_counts?: DangerCounts | null;
-  suggested_scopes?: {
-    region?: string | null;
-    country?: string | null;
-    gbu?: string | null;
-  };
-  spotlight?: {
-    title: string;
-    description: string;
-    cta_label: string;
-    cta_path: string;
-  };
-};
 
 type SubmissionRow = {
   id: number | string;
@@ -117,19 +86,6 @@ type SubmissionsResponse = {
 // ---------------------------------------------------------------------------
 // API
 // ---------------------------------------------------------------------------
-
-async function getHomeSummary(params?: {
-  month?: number;
-  year?: number;
-}): Promise<HomeSummary> {
-  const res = await api.get("/home/summary/", { params });
-  return res.data;
-}
-
-async function setCisoScope(input: { scope: string }): Promise<{ scope: string }> {
-  const res = await api.post("/home/ciso/scope/", input);
-  return res.data;
-}
 
 async function getMyRecentSubmissions(): Promise<SubmissionRow[]> {
   const res = await api.get("/submissions/", {
@@ -167,8 +123,6 @@ export default function HomePage() {
   }), [resultColors, statusColors]);
   const BADGE_W = 132;
 
-  const [scopeChoice, setScopeChoice] = React.useState("");
-
   const now = React.useMemo(() => new Date(), []);
   const currentMonth = now.getMonth() + 1;
   const currentYear = now.getFullYear();
@@ -196,14 +150,6 @@ export default function HomePage() {
     queryFn: getMyRecentSubmissions,
     enabled: !!me,
     retry: false,
-  });
-
-  const scopeMutation = useMutation({
-    mutationFn: setCisoScope,
-    onSuccess: () => {
-      homeQuery.refetch();
-      meQuery.refetch();
-    },
   });
 
   React.useEffect(() => {
@@ -248,7 +194,6 @@ export default function HomePage() {
   }
 
   const home = homeQuery.data;
-  const suggested = home?.suggested_scopes ?? {};
   const showScopeModal = Boolean(home?.show_scope_modal && isCiso);
 
   const fullName = [me.first_name, me.last_name].filter(Boolean).join(" ");
@@ -858,89 +803,7 @@ export default function HomePage() {
           </Grid>
         </Grid>
 
-        {/* ---------------------------------------------------------------- */}
-        {/* ---------------------------------------------------------------- */}
-        <Dialog open={showScopeModal} maxWidth="sm" fullWidth>
-          <DialogTitle>Select your management scope</DialogTitle>
-          <DialogContent>
-            <Stack spacing={1.25} sx={{ mt: 1 }}>
-              <Typography color="text.secondary">
-                This controls dashboards and submission visibility for your CISO view.
-              </Typography>
-
-              <Card
-                sx={{
-                  borderRadius: 3,
-                  border: `1px solid ${alpha(theme.palette.divider, theme.palette.mode === "dark" ? 0.18 : 0.7)}`,
-                  background:
-                    theme.palette.mode === "dark"
-                      ? "linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.03))"
-                      : `linear-gradient(180deg, ${alpha("#fff", 0.88)}, ${alpha(theme.palette.grey[50], 0.96)})`,
-                }}
-              >
-                <CardContent>
-                  <Stack spacing={1}>
-                    <Typography sx={{ fontWeight: 900 }} >Suggested scopes</Typography>
-
-                    <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap" }}>
-                      {suggested.region ? (
-                        <Chip
-                          icon={<PublicOutlined />}
-                          label={`Region: ${suggested.region}`}
-                          clickable
-                          onClick={() => setScopeChoice(suggested.region ?? "")}
-                          variant={scopeChoice === suggested.region ? "filled" : "outlined"}
-                        />
-                      ) : null}
-
-                      {suggested.country ? (
-                        <Chip
-                          icon={<ApartmentOutlined />}
-                          label={`Country: ${suggested.country}`}
-                          clickable
-                          onClick={() => setScopeChoice(suggested.country ?? "")}
-                          variant={scopeChoice === suggested.country ? "filled" : "outlined"}
-                        />
-                      ) : null}
-
-                      {suggested.gbu ? (
-                        <Chip
-                          label={`GBU: ${suggested.gbu}`}
-                          clickable
-                          onClick={() => setScopeChoice(suggested.gbu ?? "")}
-                          variant={scopeChoice === suggested.gbu ? "filled" : "outlined"}
-                        />
-                      ) : null}
-
-                      {!suggested.region && !suggested.country && !suggested.gbu ? (
-                        <Chip label="No suggestions" variant="outlined" />
-                      ) : null}
-                    </Stack>
-
-                    <Typography variant="caption" color="text.secondary">
-                      You can change it later if your responsibilities change.
-                    </Typography>
-
-                    {scopeMutation.isError ? (
-                      <Alert severity="error">Failed to set scope.</Alert>
-                    ) : null}
-                  </Stack>
-                </CardContent>
-              </Card>
-            </Stack>
-          </DialogContent>
-
-          <DialogActions>
-            <Button
-              variant="contained"
-              disabled={!scopeChoice || scopeMutation.isPending}
-              onClick={() => scopeMutation.mutate({ scope: scopeChoice })}
-              sx={{ borderRadius: 3, textTransform: "none", fontWeight: 950 }}
-            >
-              {scopeMutation.isPending ? "Saving…" : "Confirm scope"}
-            </Button>
-          </DialogActions>
-        </Dialog>
+        <CisoScopeDialog open={showScopeModal} />
       </Box>
     </Box>
   );

--- a/suspicious-ui/src/pages/InvestigationPage.tsx
+++ b/suspicious-ui/src/pages/InvestigationPage.tsx
@@ -73,6 +73,7 @@ import { ResultChip } from "@/shared/components/ResultChip";
 import { CopyIconButton } from "@/shared/components/CopyIconButton";
 import MailPreview from "@/shared/components/MailPreview";
 
+import { CisoScopeDialog } from "@/features/home/components/CisoScopeDialog";
 import { SoftCard } from "@/features/investigation/components/cards";
 import { InvestigationAnalyzerReportCard } from "@/features/investigation/components/InvestigationAnalyzerReportCard";
 import { CommentThread } from "@/features/comments/CommentThread";
@@ -175,6 +176,14 @@ export default function InvestigationPage() {
     () => groups.includes("CISO") || groups.includes("CERT") || groups.includes("Admin"),
     [groups]
   );
+  // A CISO with no scope set can't meaningfully browse cases yet — prompt them
+  // to pick one first (same modal Home shows on first connection).
+  const needsScope =
+    !!me &&
+    groups.includes("CISO") &&
+    !groups.includes("CERT") &&
+    !groups.includes("Admin") &&
+    !me.ciso_scope;
 
   const investigationListParams = React.useMemo(() => {
     const needsRawOrdering = sortField === "status" || sortField === "result";
@@ -197,7 +206,7 @@ export default function InvestigationPage() {
   const investigationsQuery = useQuery<InvestigationListResponse>({
     queryKey: ["investigation", investigationListParams],
     queryFn: () => getAllInvestigations(investigationListParams),
-    enabled: !!me && isElevated,
+    enabled: !!me && isElevated && !needsScope,
     retry: false,
     placeholderData: (prev) => prev,
     refetchInterval: (query) => {
@@ -379,6 +388,14 @@ export default function InvestigationPage() {
   }
   if (!isElevated) {
     return <Box sx={{ p: 3 }}><Alert severity="error">Access denied.</Alert></Box>;
+  }
+  if (needsScope) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="info">Select your management scope to view investigations.</Alert>
+        <CisoScopeDialog open />
+      </Box>
+    );
   }
   if (investigationsQuery.isLoading && !investigationsQuery.data) {
     return <Box sx={{ minHeight: "60vh", display: "grid", placeItems: "center" }}><CircularProgress /></Box>;

--- a/suspicious-ui/src/pages/__tests__/InvestigationPage.test.tsx
+++ b/suspicious-ui/src/pages/__tests__/InvestigationPage.test.tsx
@@ -28,6 +28,11 @@ vi.mock("@/features/comments/api", () => ({
   addCaseComment: vi.fn(),
 }));
 
+vi.mock("@/features/home/api", () => ({
+  getHomeSummary: vi.fn().mockResolvedValue({ suggested_scopes: {} }),
+  setCisoScope: vi.fn().mockResolvedValue({ scope: "EMEA" }),
+}));
+
 // ---------------------------------------------------------------------------
 // Test data
 // ---------------------------------------------------------------------------
@@ -386,6 +391,27 @@ describe("InvestigationPage", () => {
     await waitFor(() => {
       expect(mockGetAll).not.toHaveBeenCalled();
     });
+  });
+
+  it("prompts a scopeless CISO to set a scope instead of listing cases", async () => {
+    mockGetMe.mockResolvedValue({ ...mockMe, groups: ["CISO"], ciso_scope: "" } as never);
+
+    renderInvestigation();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /select your management scope/i })
+      ).toBeInTheDocument();
+    });
+    expect(mockGetAll).not.toHaveBeenCalled();
+  });
+
+  it("lists cases for a CISO who already has a scope", async () => {
+    mockGetMe.mockResolvedValue({ ...mockMe, groups: ["CISO"], ciso_scope: "EMEA" } as never);
+
+    renderInvestigation();
+
+    await waitFor(() => expect(mockGetAll).toHaveBeenCalled());
   });
 
   it("shows the comment thread and posts an analyst note", async () => {


### PR DESCRIPTION
## Problem

A user with a `CISOProfile` (created by LDAP sync, `process_cisos`, or admin import) **cannot open the Investigation page** — 403 on `/api/investigations/`, bounced off `/investigation`, nav item hidden.

Every RBAC check keys off membership in the **`CISO` Django group** (`IsInvestigator`, `ProtectedRoute`, `AppLayout.isElevated`, `home.py`, `dashboard.py`, `ProfileService.is_ciso`), but no CISOProfile creation path ever adds the user to that group — `Ldap.add_user_to_group` even explicitly refuses `CISO` as a reserved name.

Separately: `CISOProfile.scope` (pipe-delimited org-unit group names / `ALL`) only filtered home-page stats; the investigation list showed **every case to every investigator**. The HomePage "set scope" modal POSTed to a route that doesn't exist (`/home/ciso/scope/`) and `scope` was `read_only` on the serializer, so scope could never actually be set through the API.

## Changes

**Access**
- `profiles/signals.py` (wired via `apps.ready()`) — `post_save`/`post_delete` on `CISOProfile` grants/revokes the `CISO` group. Single chokepoint covering every creation path.
- `profiles/migrations/0014_backfill_ciso_group.py` — backfills the group for CISOProfiles that already exist (`make migrate` on deploy).

**Scope**
- `profiles/profiles_utils/scope.py` — `clean_scope` / `parse_scope_groups` / `scoped_case_queryset`; `home.py` refactored onto the shared helpers.
- `InvestigationAccessMixin` scope-filters list + detail + edit-global + redo-analysis: a CISO sees only cases whose reporter is in a scope group; `ALL` and CERT/Admin are unrestricted; an unset scope shows nothing (the UI prompts for one).
- `CISOProfile.scope` writable via `PATCH /api/profile/` with `validate_scope` — only `ALL` or a pipe-subset of the CISO's own region/country/gbu (no self-widening).
- `get_ciso_scope` normalises the default `"Not defined"` to `""`.

**Frontend**
- Scope modal extracted from `HomePage` into `features/home/components/CisoScopeDialog` + `features/home/api`; `setCisoScope` repointed to `PATCH /profile/`.
- `InvestigationPage` shows the (blocking) scope dialog to a scopeless CISO instead of an empty list; once set, the scoped list loads.

## Tests

- `api/tests/test_security_access.py`: `CISOProfileGroupSignalTests` (grant/revoke, reach investigations), `CISOInvestigationScopeTests` (list filtered, out-of-scope detail 404, unset → empty, `ALL` → all, CERT unfiltered, `PATCH` scope validation).
- `InvestigationPage.test.tsx`: scopeless CISO sees the dialog; scoped CISO gets the list.
- Backend: `test_security_access` 31/31, `profiles` 17, `dashboard` 2, full `api` 174/175 (1 pre-existing avatar/S3-env failure). Frontend: `pnpm build` + `pnpm lint` clean, `InvestigationPage` 20/20, `HomePage` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
