### PR TITLE
fix(rbac): let a CISO change their own scope after first pick

### DIFF
--- a/suspicious-ui/src/features/home/components/CisoScopeDialog.tsx
+++ b/suspicious-ui/src/features/home/components/CisoScopeDialog.tsx
@@ -19,16 +19,34 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getHomeSummary, setCisoScope } from "@/features/home/api";
 
 /**
- * The "select your management scope" modal shown to a CISO who has no scope
- * set yet — on first connection (Home) and when they open Investigation.
- * Forced modal: no dismiss until a scope is confirmed.
+ * The "select your management scope" modal.
+ *
+ * Two modes:
+ *  - forced (no `onClose`): shown to a CISO with no scope set yet, on Home and
+ *    Investigation. No dismiss until a scope is confirmed.
+ *  - editable (`onClose` given): reopened from the profile to narrow/widen an
+ *    existing scope. Dismissible, and pre-selects the current scope.
  */
-export function CisoScopeDialog({ open }: { open: boolean }) {
+export function CisoScopeDialog({
+  open,
+  onClose,
+  currentScope,
+}: {
+  open: boolean;
+  onClose?: () => void;
+  currentScope?: string;
+}) {
   const theme = useTheme();
   const isDark = theme.palette.mode === "dark";
   const qc = useQueryClient();
 
-  const [scopeChoice, setScopeChoice] = React.useState("");
+  const [scopeChoice, setScopeChoice] = React.useState(currentScope ?? "");
+
+  // Re-seed when the dialog is (re)opened from the profile.
+  React.useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (open) setScopeChoice(currentScope ?? "");
+  }, [open, currentScope]);
 
   const now = React.useMemo(() => new Date(), []);
   const summaryQuery = useQuery({
@@ -46,11 +64,17 @@ export function CisoScopeDialog({ open }: { open: boolean }) {
       qc.invalidateQueries({ queryKey: ["me"] });
       qc.invalidateQueries({ queryKey: ["homeSummary"] });
       qc.invalidateQueries({ queryKey: ["investigation"] });
+      onClose?.();
     },
   });
 
   return (
-    <Dialog open={open} maxWidth="sm" fullWidth>
+    <Dialog
+      open={open}
+      maxWidth="sm"
+      fullWidth
+      onClose={onClose ? () => onClose() : undefined}
+    >
       <DialogTitle>Select your management scope</DialogTitle>
       <DialogContent>
         <Stack spacing={1.25} sx={{ mt: 1 }}>
@@ -127,6 +151,15 @@ export function CisoScopeDialog({ open }: { open: boolean }) {
       </DialogContent>
 
       <DialogActions>
+        {onClose ? (
+          <Button
+            onClick={() => onClose()}
+            disabled={scopeMutation.isPending}
+            sx={{ borderRadius: 3, textTransform: "none", fontWeight: 800 }}
+          >
+            Cancel
+          </Button>
+        ) : null}
         <Button
           variant="contained"
           disabled={!scopeChoice || scopeMutation.isPending}

--- a/suspicious-ui/src/pages/InvestigationPage.tsx
+++ b/suspicious-ui/src/pages/InvestigationPage.tsx
@@ -126,6 +126,9 @@ export default function InvestigationPage() {
     setPage(0);
   }
   const [page, setPage] = React.useState(0);
+
+  const anyFilterActive =
+    !!qDebounced || status !== "ALL" || type !== "ALL" || result !== "ALL" || !!from || !!to;
   const [pageSize, setPageSize] = React.useState(10);
 
   const filtersActive =
@@ -661,7 +664,13 @@ export default function InvestigationPage() {
 
           {total === 0 ? (
             <Box sx={{ p: 3 }}>
-              <Alert severity="info">No investigations match your filters.</Alert>
+              <Alert severity="info">
+                {anyFilterActive
+                  ? "No investigations match your filters."
+                  : me.ciso_scope
+                    ? `No submissions have been sent within your scope (${me.ciso_scope}).`
+                    : "No investigations yet."}
+              </Alert>
             </Box>
           ) : (
             <Box sx={{ overflowX: "auto" }}>

--- a/suspicious-ui/src/pages/ProfilePage.tsx
+++ b/suspicious-ui/src/pages/ProfilePage.tsx
@@ -53,6 +53,7 @@ import { ColorSettingsPanel } from "@/features/profile/ColorSettingsPanel";
 import { AvatarPanel } from "@/features/profile/AvatarPanel";
 import { UserAvatar } from "@/features/profile/components/UserAvatar";
 import { randomSeed } from "@/features/profile/avatar";
+import { CisoScopeDialog } from "@/features/home/components/CisoScopeDialog";
 
 import {
   CaptionLabel,
@@ -395,6 +396,7 @@ export default function ProfilePage() {
   const pageStatusColors   = useStatusColors();
 
   const [section, setSection] = React.useState<Section>("preferences");
+  const [scopeDialogOpen, setScopeDialogOpen] = React.useState(false);
 
   // ── Queries ──────────────────────────────────────────────────────────────
 
@@ -713,8 +715,11 @@ export default function ProfilePage() {
                     <Chip size="small" label="Standard" variant="outlined"
                       sx={{ height: 24, "& .MuiChip-label": { fontSize: 12 } }} />
                   )}
-                  {scope ? (
-                    <Chip size="small" label={`Scope: ${scope}`} variant="outlined"
+                  {groups.includes("CISO") ? (
+                    <Chip size="small" label={`Scope: ${scope || "not set"}`} variant="outlined"
+                      clickable onClick={() => setScopeDialogOpen(true)}
+                      onDelete={() => setScopeDialogOpen(true)}
+                      deleteIcon={<TuneOutlined />}
                       sx={{ height: 24, "& .MuiChip-label": { fontSize: 12 } }} />
                   ) : null}
                 </Stack>
@@ -877,6 +882,14 @@ export default function ProfilePage() {
           </CardContent>
         </SoftCard>
       </Box>
+
+      {groups.includes("CISO") ? (
+        <CisoScopeDialog
+          open={scopeDialogOpen}
+          onClose={() => setScopeDialogOpen(false)}
+          currentScope={scope || undefined}
+        />
+      ) : null}
     </Box>
     </Skeleton>
   );

--- a/suspicious-ui/src/pages/__tests__/InvestigationPage.test.tsx
+++ b/suspicious-ui/src/pages/__tests__/InvestigationPage.test.tsx
@@ -414,6 +414,17 @@ describe("InvestigationPage", () => {
     await waitFor(() => expect(mockGetAll).toHaveBeenCalled());
   });
 
+  it("tells a scoped CISO when nothing was submitted in their scope", async () => {
+    mockGetMe.mockResolvedValue({ ...mockMe, groups: ["CISO"], ciso_scope: "RO" } as never);
+    mockGetAll.mockResolvedValue({ results: [], count: 0 } as never);
+
+    renderInvestigation();
+
+    expect(
+      await screen.findByText(/no submissions have been sent within your scope \(RO\)/i)
+    ).toBeInTheDocument();
+  });
+
   it("shows the comment thread and posts an analyst note", async () => {
     const user = userEvent.setup();
     renderInvestigation();

--- a/suspicious-ui/src/pages/__tests__/ProfilePage.test.tsx
+++ b/suspicious-ui/src/pages/__tests__/ProfilePage.test.tsx
@@ -20,6 +20,11 @@ vi.mock("@/features/profile/api", () => ({
   uploadAvatar: vi.fn(),
 }));
 
+vi.mock("@/features/home/api", () => ({
+  getHomeSummary: vi.fn().mockResolvedValue({ suggested_scopes: { country: "RO", region: "EMEA" } }),
+  setCisoScope: vi.fn().mockResolvedValue({ scope: "RO" }),
+}));
+
 
 import { getMe } from "@/api/auth";
 import { getProfile, updatePreferences, uploadAvatar } from "@/features/profile/api";
@@ -65,6 +70,24 @@ describe("ProfilePage - Test Suite", () => {
       ).toBeInTheDocument();
     });
 
+  });
+
+  describe("CISO scope", () => {
+    it("opens the scope dialog from the profile chip", async () => {
+      vi.mocked(getMe).mockResolvedValue({
+        ...fixtureMe,
+        groups: ["CISO"],
+        ciso_scope: "EMEA",
+      });
+      renderWithProviders(<ProfilePage />, { initialPath: "/profile" });
+
+      const chip = await screen.findByText(/scope: emea/i, {}, { timeout: 5000 });
+      await userEvent.click(chip);
+
+      expect(
+        await screen.findByText(/select your management scope/i)
+      ).toBeInTheDocument();
+    });
   });
 
   describe("State across navigation", () => {


### PR DESCRIPTION
## Problem

Follow-up to #322. A CISO reported seeing every submission for their whole region when they only manage a single country.

Not a filter bug — `scoped_case_queryset` is correct. The gap: the scope picker only appears while `ciso_scope` is unset (`show_scope_modal` / `needsScope` gate on `!me.ciso_scope`), and `ProfilePage` only *displayed* the scope chip. A CISO who picked a region-wide scope had no self-service way to narrow it — an admin had to edit the DB.

## Changes (frontend only)

- **`CisoScopeDialog`** — optional `onClose` + `currentScope` props. With `onClose` it's a dismissible editable modal (Cancel button, pre-selects current scope, `<Dialog onClose>`). Without `onClose`, the forced first-run modal is unchanged.
- **`ProfilePage`** — the hero *Scope* chip is now clickable for a CISO (shown for scoped and scopeless users) and reopens the dialog. Server-side `validate_scope` still blocks self-widening beyond the CISO's own region/country/gbu.
- **`InvestigationPage`** — empty state now distinguishes filters-active (*"No investigations match your filters."*) from an in-scope CISO with nothing submitted (*"No submissions have been sent within your scope (RO)."*).

## Testing

- `pnpm lint` clean, `pnpm build` clean.
- New: `ProfilePage.test.tsx` "CISO scope"; `InvestigationPage.test.tsx` scoped-CISO empty message. Targeted vitest 31/31.
- Container-verified `scoped_case_queryset` with a real `CISOProfile`:

  | scope | CISO sees |
  |---|---|
  | `RO` (country) | that country's reporters only |
  | region | all reporters in the region |
  | `ALL` | everything |
  | unset / `Not defined` / empty group | nothing |
  | self-widen country CISO -> region | `ValidationError` |

- `api.tests.test_security_access`: 31/31.

## Note for ops

Immediate unblock for the affected CISO (until this ships): `CISOProfile.objects.filter(user__username="<email>").update(scope="RO")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)