### PR TITLE
feat(rbac): multi-select scope picker + Management scope profile tab

### DIFF
--- a/suspicious-ui/src/features/home/components/CisoScopeDialog.tsx
+++ b/suspicious-ui/src/features/home/components/CisoScopeDialog.tsx
@@ -1,22 +1,7 @@
 import * as React from "react";
-import {
-  Alert,
-  Button,
-  Card,
-  CardContent,
-  Chip,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Stack,
-  Typography,
-} from "@mui/material";
-import { alpha, useTheme } from "@mui/material/styles";
-import { ApartmentOutlined, PublicOutlined } from "@mui/icons-material";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Dialog, DialogContent, DialogTitle } from "@mui/material";
 
-import { getHomeSummary, setCisoScope } from "@/features/home/api";
+import { ScopePicker } from "@/features/home/components/ScopePicker";
 
 /**
  * The "select your management scope" modal.
@@ -25,7 +10,10 @@ import { getHomeSummary, setCisoScope } from "@/features/home/api";
  *  - forced (no `onClose`): shown to a CISO with no scope set yet, on Home and
  *    Investigation. No dismiss until a scope is confirmed.
  *  - editable (`onClose` given): reopened from the profile to narrow/widen an
- *    existing scope. Dismissible, and pre-selects the current scope.
+ *    existing scope. Dismissible, pre-selects the current scope.
+ *
+ * The actual controls live in <ScopePicker>, also used inline on the profile
+ * "Management scope" tab.
  */
 export function CisoScopeDialog({
   open,
@@ -36,38 +24,6 @@ export function CisoScopeDialog({
   onClose?: () => void;
   currentScope?: string;
 }) {
-  const theme = useTheme();
-  const isDark = theme.palette.mode === "dark";
-  const qc = useQueryClient();
-
-  const [scopeChoice, setScopeChoice] = React.useState(currentScope ?? "");
-
-  // Re-seed when the dialog is (re)opened from the profile.
-  React.useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (open) setScopeChoice(currentScope ?? "");
-  }, [open, currentScope]);
-
-  const now = React.useMemo(() => new Date(), []);
-  const summaryQuery = useQuery({
-    queryKey: ["homeSummary", now.getMonth() + 1, now.getFullYear()],
-    queryFn: () => getHomeSummary({ month: now.getMonth() + 1, year: now.getFullYear() }),
-    enabled: open,
-    retry: false,
-  });
-
-  const suggested = summaryQuery.data?.suggested_scopes ?? {};
-
-  const scopeMutation = useMutation({
-    mutationFn: setCisoScope,
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["me"] });
-      qc.invalidateQueries({ queryKey: ["homeSummary"] });
-      qc.invalidateQueries({ queryKey: ["investigation"] });
-      onClose?.();
-    },
-  });
-
   return (
     <Dialog
       open={open}
@@ -77,98 +33,14 @@ export function CisoScopeDialog({
     >
       <DialogTitle>Select your management scope</DialogTitle>
       <DialogContent>
-        <Stack spacing={1.25} sx={{ mt: 1 }}>
-          <Typography color="text.secondary">
-            This controls dashboards, investigations and submission visibility for your CISO view.
-          </Typography>
-
-          <Card
-            sx={{
-              borderRadius: 3,
-              border: `1px solid ${alpha(theme.palette.divider, isDark ? 0.18 : 0.7)}`,
-              background: isDark
-                ? "linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.03))"
-                : `linear-gradient(180deg, ${alpha("#fff", 0.88)}, ${alpha(theme.palette.grey[50], 0.96)})`,
-            }}
-          >
-            <CardContent>
-              <Stack spacing={1}>
-                <Typography sx={{ fontWeight: 900 }}>Suggested scopes</Typography>
-
-                <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap" }}>
-                  {suggested.region ? (
-                    <Chip
-                      icon={<PublicOutlined />}
-                      label={`Region: ${suggested.region}`}
-                      clickable
-                      onClick={() => setScopeChoice(suggested.region ?? "")}
-                      variant={scopeChoice === suggested.region ? "filled" : "outlined"}
-                    />
-                  ) : null}
-
-                  {suggested.country ? (
-                    <Chip
-                      icon={<ApartmentOutlined />}
-                      label={`Country: ${suggested.country}`}
-                      clickable
-                      onClick={() => setScopeChoice(suggested.country ?? "")}
-                      variant={scopeChoice === suggested.country ? "filled" : "outlined"}
-                    />
-                  ) : null}
-
-                  {suggested.gbu ? (
-                    <Chip
-                      label={`GBU: ${suggested.gbu}`}
-                      clickable
-                      onClick={() => setScopeChoice(suggested.gbu ?? "")}
-                      variant={scopeChoice === suggested.gbu ? "filled" : "outlined"}
-                    />
-                  ) : null}
-
-                  <Chip
-                    label="All cases"
-                    clickable
-                    onClick={() => setScopeChoice("ALL")}
-                    variant={scopeChoice === "ALL" ? "filled" : "outlined"}
-                  />
-
-                  {!suggested.region && !suggested.country && !suggested.gbu ? (
-                    <Chip label="No org-unit suggestions" variant="outlined" />
-                  ) : null}
-                </Stack>
-
-                <Typography variant="caption" color="text.secondary">
-                  You can change it later from your profile if your responsibilities change.
-                </Typography>
-
-                {scopeMutation.isError ? (
-                  <Alert severity="error">Failed to set scope.</Alert>
-                ) : null}
-              </Stack>
-            </CardContent>
-          </Card>
-        </Stack>
+        <ScopePicker
+          key={open ? "open" : "closed"}
+          enabled={open}
+          currentScope={currentScope}
+          onSaved={onClose}
+          onCancel={onClose}
+        />
       </DialogContent>
-
-      <DialogActions>
-        {onClose ? (
-          <Button
-            onClick={() => onClose()}
-            disabled={scopeMutation.isPending}
-            sx={{ borderRadius: 3, textTransform: "none", fontWeight: 800 }}
-          >
-            Cancel
-          </Button>
-        ) : null}
-        <Button
-          variant="contained"
-          disabled={!scopeChoice || scopeMutation.isPending}
-          onClick={() => scopeMutation.mutate({ scope: scopeChoice })}
-          sx={{ borderRadius: 3, textTransform: "none", fontWeight: 950 }}
-        >
-          {scopeMutation.isPending ? "Saving…" : "Confirm scope"}
-        </Button>
-      </DialogActions>
     </Dialog>
   );
 }

--- a/suspicious-ui/src/features/home/components/ScopePicker.tsx
+++ b/suspicious-ui/src/features/home/components/ScopePicker.tsx
@@ -1,0 +1,161 @@
+import * as React from "react";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { ApartmentOutlined, PublicOutlined, BusinessOutlined } from "@mui/icons-material";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { getHomeSummary, setCisoScope } from "@/features/home/api";
+
+const ALL = "ALL";
+
+/** Parse a stored scope string into the checkbox model. */
+function parse(scope: string | undefined): { all: boolean; groups: string[] } {
+  const s = (scope ?? "").trim();
+  if (!s || s.toUpperCase() === ALL) return { all: s.toUpperCase() === ALL, groups: [] };
+  return { all: false, groups: s.split("|").map((p) => p.trim()).filter(Boolean) };
+}
+
+function serialize(all: boolean, groups: string[]): string {
+  return all ? ALL : [...groups].sort().join("|");
+}
+
+/**
+ * The management-scope multi-select, shared by the forced first-run dialog
+ * (CisoScopeDialog) and the "Management scope" profile tab.
+ *
+ * A CISO may pick any combination of their own org units (region / country /
+ * GBU) — cases are matched if the reporter is in *any* selected group — or
+ * "All cases". Server-side `validate_scope` rejects anything outside those.
+ */
+export function ScopePicker({
+  currentScope,
+  onSaved,
+  onCancel,
+  enabled = true,
+}: {
+  currentScope?: string;
+  onSaved?: () => void;
+  onCancel?: () => void;
+  /** Skip fetching suggestions until the picker is actually visible. */
+  enabled?: boolean;
+}) {
+  const qc = useQueryClient();
+
+  const now = React.useMemo(() => new Date(), []);
+  const summaryQuery = useQuery({
+    queryKey: ["homeSummary", now.getMonth() + 1, now.getFullYear()],
+    queryFn: () => getHomeSummary({ month: now.getMonth() + 1, year: now.getFullYear() }),
+    enabled,
+    retry: false,
+  });
+  const suggested = summaryQuery.data?.suggested_scopes ?? {};
+
+  const options = React.useMemo(
+    () =>
+      [
+        { key: suggested.region, label: `Region: ${suggested.region}`, icon: <PublicOutlined fontSize="small" /> },
+        { key: suggested.country, label: `Country: ${suggested.country}`, icon: <ApartmentOutlined fontSize="small" /> },
+        { key: suggested.gbu, label: `GBU: ${suggested.gbu}`, icon: <BusinessOutlined fontSize="small" /> },
+      ].filter((o): o is { key: string; label: string; icon: React.ReactElement } => !!o.key),
+    [suggested.region, suggested.country, suggested.gbu],
+  );
+
+  // Callers that need to re-seed from a changed `currentScope` (the dialog on
+  // reopen) pass a `key` to remount instead — keeps this state dead simple.
+  const initial = React.useMemo(() => parse(currentScope), [currentScope]);
+  const [all, setAll] = React.useState(initial.all);
+  const [groups, setGroups] = React.useState<string[]>(initial.groups);
+
+  const toggleGroup = (key: string) =>
+    setGroups((prev) => (prev.includes(key) ? prev.filter((g) => g !== key) : [...prev, key]));
+
+  const next = serialize(all, groups);
+  const dirty = next !== serialize(initial.all, initial.groups);
+  const empty = !all && groups.length === 0;
+
+  const mutation = useMutation({
+    mutationFn: setCisoScope,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["me"] });
+      qc.invalidateQueries({ queryKey: ["homeSummary"] });
+      qc.invalidateQueries({ queryKey: ["investigation"] });
+      onSaved?.();
+    },
+  });
+
+  return (
+    <Stack spacing={1.5}>
+      <Typography color="text.secondary">
+        This controls dashboards, investigations and submission visibility for your CISO view.
+        Cases are shown when the reporter belongs to any scope you select.
+      </Typography>
+
+      <FormGroup>
+        {options.map((o) => (
+          <FormControlLabel
+            key={o.key}
+            control={
+              <Checkbox
+                checked={all || groups.includes(o.key)}
+                disabled={all}
+                onChange={() => toggleGroup(o.key)}
+              />
+            }
+            label={
+              <Stack direction="row" spacing={0.75} sx={{ alignItems: "center" }}>
+                {o.icon}
+                <span>{o.label}</span>
+              </Stack>
+            }
+          />
+        ))}
+        {options.length === 0 && !summaryQuery.isPending ? (
+          <Typography variant="body2" color="text.secondary">
+            No org-unit suggestions available for your profile.
+          </Typography>
+        ) : null}
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={all}
+              onChange={() => {
+                setAll((v) => !v);
+                setGroups([]);
+              }}
+            />
+          }
+          label="All cases (no restriction)"
+        />
+      </FormGroup>
+
+      {mutation.isError ? <Alert severity="error">Failed to save scope.</Alert> : null}
+
+      <Stack direction="row" spacing={1} sx={{ justifyContent: "flex-end" }}>
+        {onCancel ? (
+          <Button
+            onClick={onCancel}
+            disabled={mutation.isPending}
+            sx={{ borderRadius: 3, textTransform: "none", fontWeight: 800 }}
+          >
+            Cancel
+          </Button>
+        ) : null}
+        <Button
+          variant="contained"
+          disabled={empty || !dirty || mutation.isPending}
+          onClick={() => mutation.mutate({ scope: next })}
+          sx={{ borderRadius: 3, textTransform: "none", fontWeight: 950 }}
+        >
+          {mutation.isPending ? "Saving…" : "Save scope"}
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/suspicious-ui/src/pages/ProfilePage.tsx
+++ b/suspicious-ui/src/pages/ProfilePage.tsx
@@ -53,7 +53,7 @@ import { ColorSettingsPanel } from "@/features/profile/ColorSettingsPanel";
 import { AvatarPanel } from "@/features/profile/AvatarPanel";
 import { UserAvatar } from "@/features/profile/components/UserAvatar";
 import { randomSeed } from "@/features/profile/avatar";
-import { CisoScopeDialog } from "@/features/home/components/CisoScopeDialog";
+import { ScopePicker } from "@/features/home/components/ScopePicker";
 
 import {
   CaptionLabel,
@@ -72,7 +72,7 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
-type Section = "preferences" | "appearance" | "colors" | "avatar";
+type Section = "preferences" | "appearance" | "colors" | "avatar" | "scope";
 
 // ---------------------------------------------------------------------------
 // ToggleRow
@@ -396,7 +396,6 @@ export default function ProfilePage() {
   const pageStatusColors   = useStatusColors();
 
   const [section, setSection] = React.useState<Section>("preferences");
-  const [scopeDialogOpen, setScopeDialogOpen] = React.useState(false);
 
   // ── Queries ──────────────────────────────────────────────────────────────
 
@@ -616,6 +615,8 @@ export default function ProfilePage() {
   const scope      = (me as any)?.ciso_scope;
   const displayName = [me.first_name, me.last_name].filter(Boolean).join(" ") || me.username;
 
+  const isCiso = groups.includes("CISO");
+
   const NAV = [
     {
       key: "preferences" as Section,
@@ -624,6 +625,15 @@ export default function ProfilePage() {
       icon: <TuneOutlined />,
       dirty: prefsDirty,
     },
+    ...(isCiso
+      ? [{
+          key: "scope" as Section,
+          label: "Management scope",
+          sub: "Which submissions you can see",
+          icon: <ShieldOutlined />,
+          dirty: false,
+        }]
+      : []),
     {
       key: "appearance" as Section,
       label: "Appearance",
@@ -645,7 +655,7 @@ export default function ProfilePage() {
       icon: <PersonOutlined />,
       dirty: avatarDirty,
     },
-  ] as const;
+  ];
 
   const anyDirty = prefsDirty || themeDirty || avatarDirty;
 
@@ -715,11 +725,9 @@ export default function ProfilePage() {
                     <Chip size="small" label="Standard" variant="outlined"
                       sx={{ height: 24, "& .MuiChip-label": { fontSize: 12 } }} />
                   )}
-                  {groups.includes("CISO") ? (
+                  {isCiso ? (
                     <Chip size="small" label={`Scope: ${scope || "not set"}`} variant="outlined"
-                      clickable onClick={() => setScopeDialogOpen(true)}
-                      onDelete={() => setScopeDialogOpen(true)}
-                      deleteIcon={<TuneOutlined />}
+                      clickable onClick={() => setSection("scope")}
                       sx={{ height: 24, "& .MuiChip-label": { fontSize: 12 } }} />
                   ) : null}
                 </Stack>
@@ -862,6 +870,16 @@ export default function ProfilePage() {
               />
             ) : section === "colors" ? (
               <ColorsPanel />
+            ) : section === "scope" ? (
+              <Stack spacing={1.5}>
+                <Box>
+                  <Typography sx={{ fontWeight: 950, fontSize: 18 }}>Management scope</Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    Current scope: <b>{scope || "not set"}</b>
+                  </Typography>
+                </Box>
+                <ScopePicker currentScope={scope || undefined} enabled />
+              </Stack>
             ) : (
               <AvatarPanel
                 style={avatarStyle} seed={avatarSeed}
@@ -882,14 +900,6 @@ export default function ProfilePage() {
           </CardContent>
         </SoftCard>
       </Box>
-
-      {groups.includes("CISO") ? (
-        <CisoScopeDialog
-          open={scopeDialogOpen}
-          onClose={() => setScopeDialogOpen(false)}
-          currentScope={scope || undefined}
-        />
-      ) : null}
     </Box>
     </Skeleton>
   );

--- a/suspicious-ui/src/pages/__tests__/ProfilePage.test.tsx
+++ b/suspicious-ui/src/pages/__tests__/ProfilePage.test.tsx
@@ -73,19 +73,29 @@ describe("ProfilePage - Test Suite", () => {
   });
 
   describe("CISO scope", () => {
-    it("opens the scope dialog from the profile chip", async () => {
+    beforeEach(() => {
       vi.mocked(getMe).mockResolvedValue({
         ...fixtureMe,
         groups: ["CISO"],
         ciso_scope: "EMEA",
       });
+    });
+
+    it("shows a Management scope tab for a CISO", async () => {
+      renderWithProviders(<ProfilePage />, { initialPath: "/profile" });
+      expect(
+        await screen.findByText(/management scope/i, {}, { timeout: 5000 })
+      ).toBeInTheDocument();
+    });
+
+    it("opens the scope tab from the profile chip", async () => {
       renderWithProviders(<ProfilePage />, { initialPath: "/profile" });
 
       const chip = await screen.findByText(/scope: emea/i, {}, { timeout: 5000 });
       await userEvent.click(chip);
 
       expect(
-        await screen.findByText(/select your management scope/i)
+        await screen.findByRole("button", { name: /save scope/i })
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Follow-up to #323

Two UX asks on the CISO scope picker:

1. **See what's selected.** The suggested-scope chips only flipped `variant` (filled/outlined) — hard to tell what was active. Now checkboxes.
2. **Make it a real profile tab**, not just the hero badge.

## Changes (frontend only)

- **`ScopePicker`** (new, `features/home/components/`) — the scope controls extracted into one shared component:
  - Checkboxes for each org unit (Region / Country / GBU) + **All cases**. Selection state is now obvious.
  - **Multi-select**: `CISOProfile.scope` already stores `"EMEA|FR"` and `validate_scope` already accepts a pipe-joined subset of the CISO's own units — the UI just never exposed it. Cases match if the reporter is in *any* selected group.
  - *All cases* is exclusive: checking it clears and disables the others.
  - Save is disabled unless the selection changed and is non-empty.
- **`CisoScopeDialog`** — now a thin `<Dialog>` wrapper around `<ScopePicker>`. Forced first-run mode (Home / Investigation, no dismiss) unchanged.
- **`ProfilePage`** — **Management scope** is its own sidebar tab for a CISO, rendering `<ScopePicker>` inline (no modal). The hero *Scope* chip jumps to that tab.

## Testing

- `pnpm lint` clean, `pnpm build` clean.
- `ProfilePage.test.tsx` — "shows a Management scope tab", "opens the scope tab from the profile chip". `InvestigationPage` / `HomePage` scope tests still green (36/36 across the three page suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)