### PR TITLE
fix(rbac): AND multi-group scope, reserve "ALL" for Admin

### DIFF
--- a/Suspicious/Suspicious/api/serializers/profile.py
+++ b/Suspicious/Suspicious/api/serializers/profile.py
@@ -238,14 +238,25 @@ class CISOProfileSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "creation_date", "last_update"]
 
     def validate_scope(self, value):
-        """A CISO may only scope themselves to "ALL" or a pipe-joined subset
-        of their own org units (region / country / gbu). This stops a CISO
-        widening their own visibility to an arbitrary group."""
+        """A CISO may only scope themselves to a pipe-joined subset of their
+        own org units (region / country / gbu). "ALL" (no restriction) is
+        reserved for members of the Admin group. This stops a CISO widening
+        their own visibility beyond their remit."""
         normalized = (value or "").strip()
-        if not normalized or normalized.upper() == "ALL":
-            return "ALL" if normalized else normalized
-
         instance = self.instance
+
+        if not normalized:
+            return normalized
+        if normalized.upper() == "ALL":
+            is_admin = bool(
+                instance
+                and instance.user.groups.filter(name="Admin").exists()
+            )
+            if not is_admin:
+                raise serializers.ValidationError(
+                    'Scope "ALL" is reserved for administrators.'
+                )
+            return "ALL"
         allowed = {
             str(getattr(instance, attr, "") or "").strip()
             for attr in ("region", "country", "gbu")
@@ -256,9 +267,10 @@ class CISOProfileSerializer(serializers.ModelSerializer):
         invalid = [p for p in parts if p not in allowed]
         if not parts or invalid:
             raise serializers.ValidationError(
-                f"Invalid scope. Allowed values: {sorted(allowed) + ['ALL']}."
+                f"Invalid scope. Allowed values: {sorted(allowed)} "
+                "(combine with '|' to narrow)."
             )
-        return "|".join(parts)
+        return "|".join(sorted(parts))
 
     def validate_theme(self, value):
         valid = {choice[0] for choice in Theme.choices}

--- a/Suspicious/Suspicious/api/tests/test_security_access.py
+++ b/Suspicious/Suspicious/api/tests/test_security_access.py
@@ -188,6 +188,34 @@ class CISOInvestigationScopeTests(TestCase):
         self.profile.refresh_from_db()
         self.assertEqual(self.profile.scope, "FR")
 
+    def test_multi_group_scope_is_intersection(self):
+        # A reporter in FR *and* MG; another in FR only.
+        both = _make_user("fr_mg_rep", groups=["FR", "EMEA", "MG"])
+        fr_only = _make_user("fr_only_rep", groups=["FR", "EMEA"])
+        both_case = Case.objects.create(reporter=both, description="both")
+        fr_case = Case.objects.create(reporter=fr_only, description="fr")
+
+        self.profile.scope = "FR|MG"
+        self.profile.save()
+        self.client.force_authenticate(self.ciso)
+        resp = self.client.get(reverse("investigation-list"))
+        # AND: only the reporter in both groups, not fr_only or the EMEA case.
+        self.assertEqual(self._ids(resp), {both_case.id})
+        self.assertNotIn(fr_case.id, self._ids(resp))
+
+    def test_all_scope_rejected_for_non_admin(self):
+        self.client.force_authenticate(self.ciso)
+        resp = self.client.patch(reverse("profile"), {"scope": "ALL"}, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_all_scope_allowed_for_admin(self):
+        self.ciso.groups.add(Group.objects.get_or_create(name="Admin")[0])
+        self.client.force_authenticate(self.ciso)
+        resp = self.client.patch(reverse("profile"), {"scope": "ALL"}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.scope, "ALL")
+
 
 class DashboardPerUserStatsAccessTests(TestCase):
     """Regression for the per-user-stats data leak: regular reporters must

--- a/Suspicious/Suspicious/api/views/home.py
+++ b/Suspicious/Suspicious/api/views/home.py
@@ -137,6 +137,12 @@ class HomeSummaryView(APIView):
 
         scope_groups = parse_scope_groups(scope)
         if scope_groups is not None:
+            # ponytail: exact for a single-group scope. For a multi-group
+            # (AND) scope the per-group snapshot can't express the
+            # intersection, so this KPI tile is an upper bound — the
+            # Investigation list (scoped_case_queryset) is the source of
+            # truth. Recompute from Case here if multi-group KPIs must be
+            # exact.
             qs = qs.filter(group_name__in=scope_groups)
 
         return cls._normalize_stats(qs.aggregate(**cls._build_aggregate_kwargs()))

--- a/Suspicious/Suspicious/profiles/profiles_utils/scope.py
+++ b/Suspicious/Suspicious/profiles/profiles_utils/scope.py
@@ -1,9 +1,12 @@
 """CISO scope helpers.
 
 A CISOProfile.scope is a pipe-delimited list of org-unit group names
-(e.g. "EMEA|FR"), the literal "ALL", or unset ("Not defined" / "").
-A case belongs to a scope when its reporter is in one of those groups —
-the same rule dashboard.update_group_monthly_stats uses.
+(e.g. "EMEA|Off GBU"), the literal "ALL", or unset ("Not defined" / "").
+Each name is a different org dimension (region / country / GBU), so
+multiple names are AND-ed: a case is in scope when its reporter is in
+*every* selected group. A Romanian Off-GBU reporter carries
+{RO, EMEA, Off GBU}, so "RO|Off GBU" narrows to that reporter — it does
+not union everyone in RO with everyone in Off GBU.
 """
 from __future__ import annotations
 
@@ -54,4 +57,8 @@ def scoped_case_queryset(queryset, user):
         return queryset
     if not groups:
         return queryset.none()
-    return queryset.filter(reporter__groups__name__in=groups).distinct()
+    # AND across dimensions: chained .filter() on a reverse M2M requires the
+    # reporter to be in *all* of the named groups.
+    for name in groups:
+        queryset = queryset.filter(reporter__groups__name=name)
+    return queryset.distinct()

--- a/suspicious-ui/src/features/home/components/CisoScopeDialog.tsx
+++ b/suspicious-ui/src/features/home/components/CisoScopeDialog.tsx
@@ -19,10 +19,13 @@ export function CisoScopeDialog({
   open,
   onClose,
   currentScope,
+  allowAll = false,
 }: {
   open: boolean;
   onClose?: () => void;
   currentScope?: string;
+  /** Show the "All cases" option (Admin group only). */
+  allowAll?: boolean;
 }) {
   return (
     <Dialog
@@ -37,6 +40,7 @@ export function CisoScopeDialog({
           key={open ? "open" : "closed"}
           enabled={open}
           currentScope={currentScope}
+          allowAll={allowAll}
           onSaved={onClose}
           onCancel={onClose}
         />

--- a/suspicious-ui/src/features/home/components/ScopePicker.tsx
+++ b/suspicious-ui/src/features/home/components/ScopePicker.tsx
@@ -30,21 +30,26 @@ function serialize(all: boolean, groups: string[]): string {
  * The management-scope multi-select, shared by the forced first-run dialog
  * (CisoScopeDialog) and the "Management scope" profile tab.
  *
- * A CISO may pick any combination of their own org units (region / country /
- * GBU) — cases are matched if the reporter is in *any* selected group — or
- * "All cases". Server-side `validate_scope` rejects anything outside those.
+ * A CISO picks a combination of their own org units (region / country / GBU).
+ * Multiple picks are AND-ed server-side — "Country: RO" + "GBU: Off GBU"
+ * narrows to reporters in both, it does not widen. "All cases" (no
+ * restriction) is only offered to Admin-group users; `validate_scope`
+ * enforces the same server-side.
  */
 export function ScopePicker({
   currentScope,
   onSaved,
   onCancel,
   enabled = true,
+  allowAll = false,
 }: {
   currentScope?: string;
   onSaved?: () => void;
   onCancel?: () => void;
   /** Skip fetching suggestions until the picker is actually visible. */
   enabled?: boolean;
+  /** Show the "All cases" option (Admin group only). */
+  allowAll?: boolean;
 }) {
   const qc = useQueryClient();
 
@@ -69,7 +74,10 @@ export function ScopePicker({
 
   // Callers that need to re-seed from a changed `currentScope` (the dialog on
   // reopen) pass a `key` to remount instead — keeps this state dead simple.
-  const initial = React.useMemo(() => parse(currentScope), [currentScope]);
+  const initial = React.useMemo(() => {
+    const p = parse(currentScope);
+    return allowAll ? p : { all: false, groups: p.groups };
+  }, [currentScope, allowAll]);
   const [all, setAll] = React.useState(initial.all);
   const [groups, setGroups] = React.useState<string[]>(initial.groups);
 
@@ -94,7 +102,8 @@ export function ScopePicker({
     <Stack spacing={1.5}>
       <Typography color="text.secondary">
         This controls dashboards, investigations and submission visibility for your CISO view.
-        Cases are shown when the reporter belongs to any scope you select.
+        Picking more than one narrows the scope — a case is shown only when its reporter
+        belongs to every unit you select.
       </Typography>
 
       <FormGroup>
@@ -121,18 +130,20 @@ export function ScopePicker({
             No org-unit suggestions available for your profile.
           </Typography>
         ) : null}
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={all}
-              onChange={() => {
-                setAll((v) => !v);
-                setGroups([]);
-              }}
-            />
-          }
-          label="All cases (no restriction)"
-        />
+        {allowAll ? (
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={all}
+                onChange={() => {
+                  setAll((v) => !v);
+                  setGroups([]);
+                }}
+              />
+            }
+            label="All cases (no restriction)"
+          />
+        ) : null}
       </FormGroup>
 
       {mutation.isError ? <Alert severity="error">Failed to save scope.</Alert> : null}

--- a/suspicious-ui/src/pages/HomePage.tsx
+++ b/suspicious-ui/src/pages/HomePage.tsx
@@ -803,7 +803,7 @@ export default function HomePage() {
           </Grid>
         </Grid>
 
-        <CisoScopeDialog open={showScopeModal} />
+        <CisoScopeDialog open={showScopeModal} allowAll={groups.includes("Admin")} />
       </Box>
     </Box>
   );

--- a/suspicious-ui/src/pages/InvestigationPage.tsx
+++ b/suspicious-ui/src/pages/InvestigationPage.tsx
@@ -396,7 +396,7 @@ export default function InvestigationPage() {
     return (
       <Box sx={{ p: 3 }}>
         <Alert severity="info">Select your management scope to view investigations.</Alert>
-        <CisoScopeDialog open />
+        <CisoScopeDialog open allowAll={groups.includes("Admin")} />
       </Box>
     );
   }

--- a/suspicious-ui/src/pages/ProfilePage.tsx
+++ b/suspicious-ui/src/pages/ProfilePage.tsx
@@ -878,7 +878,11 @@ export default function ProfilePage() {
                     Current scope: <b>{scope || "not set"}</b>
                   </Typography>
                 </Box>
-                <ScopePicker currentScope={scope || undefined} enabled />
+                <ScopePicker
+                  currentScope={scope || undefined}
+                  enabled
+                  allowAll={groups.includes("Admin")}
+                />
               </Stack>
             ) : (
               <AvatarPanel

--- a/suspicious-ui/src/pages/__tests__/ProfilePage.test.tsx
+++ b/suspicious-ui/src/pages/__tests__/ProfilePage.test.tsx
@@ -98,6 +98,26 @@ describe("ProfilePage - Test Suite", () => {
         await screen.findByRole("button", { name: /save scope/i })
       ).toBeInTheDocument();
     });
+
+    it("hides 'All cases' from a non-Admin CISO", async () => {
+      renderWithProviders(<ProfilePage />, { initialPath: "/profile" });
+      const chip = await screen.findByText(/scope: emea/i, {}, { timeout: 5000 });
+      await userEvent.click(chip);
+      await screen.findByRole("button", { name: /save scope/i });
+      expect(screen.queryByLabelText(/all cases/i)).not.toBeInTheDocument();
+    });
+
+    it("shows 'All cases' to an Admin-group CISO", async () => {
+      vi.mocked(getMe).mockResolvedValue({
+        ...fixtureMe,
+        groups: ["CISO", "Admin"],
+        ciso_scope: "EMEA",
+      });
+      renderWithProviders(<ProfilePage />, { initialPath: "/profile" });
+      const chip = await screen.findByText(/scope: emea/i, {}, { timeout: 5000 });
+      await userEvent.click(chip);
+      expect(await screen.findByLabelText(/all cases/i)).toBeInTheDocument();
+    });
   });
 
   describe("State across navigation", () => {


### PR DESCRIPTION
## Follow-up to #324 — two review points

### 1. Multi-group scope is now AND (intersection), not OR

Region / country / GBU are different org dimensions and a reporter carries a group for each (a Romanian Off-GBU reporter → `{RO, EMEA, Off GBU}`). So `RO|Off GBU` must mean *"Off-GBU reporters in Romania"* — a narrowing — not *"everyone in RO, plus everyone in Off GBU worldwide"*.

- `scoped_case_queryset` chains `.filter(reporter__groups__name=<name>)` per selected name (reverse-M2M AND).
- `validate_scope` sorts the parts for a stable stored value.
- `home._aggregate_scope_stats` keeps the per-group snapshot sum — exact for a single-group scope, an upper bound for multi-group (ponytail-noted). The Investigation list is the source of truth.
- Picker help text updated: *"a case is shown only when its reporter belongs to every unit you select."*

### 2. "All cases" (no restriction) reserved for Admin

- `validate_scope` rejects `scope="ALL"` unless the CISO is in the **Admin** group.
- `ScopePicker` only renders the "All cases" checkbox when `allowAll` is passed (`groups.includes("Admin")`), wired from HomePage / InvestigationPage / ProfilePage.
- A stored `"ALL"` on a non-Admin degrades to "pick a real scope".

(Note: a CERT/Admin-group user is already unrestricted in `scoped_case_queryset` before scope is even read, so `ALL` only ever mattered for a plain CISO.)

## Testing

- Container: `api.tests.test_security_access` 34/34 — `+test_multi_group_scope_is_intersection`, `+test_all_scope_rejected_for_non_admin`, `+test_all_scope_allowed_for_admin`.
- Verified `scoped_case_queryset` matrix: `RO`→all RO, `Off GBU`→all Off GBU, `RO|Off GBU`→intersection only, `EMEA|Off GBU`→2, unset→none.
- `ProfilePage.test.tsx`: "All cases" hidden for a CISO, shown for an Admin-group CISO. `pnpm lint` + `pnpm build` clean; page suites 38/38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
